### PR TITLE
Return 200 on no results, error message on 500

### DIFF
--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -17,7 +17,7 @@ module.exports = function( req, res ){
   // fetch all result docs by id
   ph.store.getMany( ids, function( err, results ){
     if( err ){ return res.status(500).send({}); }
-    if( !results || !results.length ){ return res.status(404).send({}); }
+    if( !results || !results.length ){ return res.status(200).send([]); }
 
     // get a list of parent ids
     var parentIds = getParentIds( results );

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -16,7 +16,7 @@ module.exports = function( req, res ){
 
   // fetch all result docs by id
   ph.store.getMany( ids, function( err, results ){
-    if( err ){ return res.status(500).send({}); }
+    if( err ){ return res.status(500).send(err); }
     if( !results || !results.length ){ return res.status(200).send([]); }
 
     // get a list of parent ids


### PR DESCRIPTION
- return a 200 if there are no results.  returning a 404 is misleading and we'll end up with support questions for users who don't know if they're entering the URL correctly.
- return the error message on a 500, which will be great for log files.  