### PR TITLE
population: update target fields after consulting WOF team

### DIFF
--- a/cmd/jq.filter
+++ b/cmd/jq.filter
@@ -1,15 +1,18 @@
 .properties | with_entries(
   select( .key |
-    test("^wof:(id|name|placetype|hierarchy|country_alpha3|abbreviation|superseded_by|label)$"),
+    test("^wof:(id|name|placetype|hierarchy|country_alpha3|abbreviation|superseded_by|label|population)$"),
     test("^lbl:(bbox|latitude|longitude)$"),
     test("^geom:(area|bbox|latitude|longitude)$"),
     test("^iso:(country)$"),
-    test("^ne:(iso_a2|iso_a3)$"),
+    test("^ne:(iso_a2|iso_a3|pop_est)$"),
     test("^edtf:(deprecated)$"),
     test("^mz:(is_current|population)$"),
-    test("^gn:(population)$"),
+    test("^gn:(population|pop)$"),
     test("^zs:(pop10)$"),
-    test("^qs:(pop)$"),
+    test("^qs:(pop|gn_pop)$"),
+    test("^wk:(population)$"),
+    test("^meso:(pop)$"),
+    test("^statoids:(population)$"),
     test("^name:")
   )
 )

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -126,12 +126,19 @@ module.exports.isValidWofRecord = function( id, wof ){
 };
 
 // this function favors mz:population when available, falling back to other properties.
-// logic copied from: pelias/whosonfirst src/components/extractFields.js
+// see: https://github.com/whosonfirst-data/whosonfirst-data/issues/240#issuecomment-294907374
 function getPopulation( wof ) {
-       if( wof['mz:population'] ){ return wof['mz:population']; }
-  else if( wof['gn:population'] ){ return wof['gn:population']; }
-  else if( wof['zs:pop10'] ){      return wof['zs:pop10']; }
-  else if( wof['qs:pop'] ){        return wof['qs:pop']; }
+       if( wof['mz:population'] ){          return wof['mz:population']; }
+  else if( wof['wof:population'] ){         return wof['wof:population']; }
+  else if( wof['wk:population'] ){          return wof['wk:population']; }
+  else if( wof['gn:population'] ){          return wof['gn:population']; }
+  else if( wof['gn:pop'] ){                 return wof['gn:pop']; }
+  else if( wof['qs:pop'] ){                 return wof['qs:pop']; }
+  else if( wof['qs:gn_pop'] ){              return wof['qs:gn_pop']; }
+  else if( wof['zs:pop10'] ){               return wof['zs:pop10']; }
+  else if( wof['meso:pop'] ){               return wof['meso:pop']; }
+  else if( wof['statoids:population'] ){    return wof['statoids:population']; }
+  else if( wof['ne:pop_est'] ){             return wof['ne:pop_est']; }
 }
 
 // abbreviations and ISO codes


### PR DESCRIPTION
I noticed that some of the population info from WOF was not being imported correctly, after a discussion in https://github.com/whosonfirst-data/whosonfirst-data/issues/240#issuecomment-294907374 I have updated the list of population fields we target for import.

note: the `getPopulation()` function also exists in the `pelias/whosonfirst` repository and may also need to be updated there.

note: there is also a function named `isValidWofRecord()` which could also be shared with the `pelias/whosonfirst` repo, I was given this logic by mraaronland