### PR TITLE
USA replace eng with label

### DIFF
--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -85,6 +85,11 @@ function insertWofRecord( wof, next ){
     }
   }
 
+  // In the USA we would like to favor the 'wof:label' property over the 'name:eng_x_preferred' property.
+  if( 'US' === wof['wof:country'] && wof['wof:label'] ){
+    doc.names.eng = [ wof['wof:label'] ];
+  }
+
   // --- graph ---
   for( var h in wof['wof:hierarchy'] ){
    for( var i in wof['wof:hierarchy'][h] ){

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -634,6 +634,77 @@ module.exports.add_names = function(test, util) {
 
 };
 
+// In the USA we would like to favor the 'wof:label' property over the 'name:eng_x_preferred' property.
+module.exports.usa_english_name_override_with_label = function(test, util) {
+
+  test( 'override name:eng_x_preferred with wof:label', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': 102085121,
+      'wof:country': 'US',
+      'wof:label': 'Lake County',
+      'name:eng_x_preferred': [ 'Lake' ],
+    }, function(){
+      t.deepEqual( mock._calls.set.length, 1 );
+      t.deepEqual( mock._calls.set[0][1].names, { eng: [ 'Lake County' ] } );
+      t.end();
+    });
+  });
+
+  test( 'no country', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': 102085121,
+      'wof:label': 'Lake County',
+      'name:eng_x_preferred': [ 'Lake' ],
+    }, function(){
+      t.deepEqual( mock._calls.set.length, 1 );
+      t.deepEqual( mock._calls.set[0][1].names, { eng: [ 'Lake' ] } );
+      t.end();
+    });
+  });
+
+  test( 'no label', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': 102085121,
+      'wof:country': 'US',
+      'name:eng_x_preferred': [ 'Lake' ],
+    }, function(){
+      t.deepEqual( mock._calls.set.length, 1 );
+      t.deepEqual( mock._calls.set[0][1].names, { eng: [ 'Lake' ] } );
+      t.end();
+    });
+  });
+
+  test( 'no eng_x_preferred', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': 102085121,
+      'wof:country': 'US',
+      'wof:label': 'Lake County'
+    }, function(){
+      t.deepEqual( mock._calls.set.length, 1 );
+      t.deepEqual( mock._calls.set[0][1].names, { eng: [ 'Lake County' ] } );
+      t.end();
+    });
+  });
+
+  test( 'wrong country', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': 102085121,
+      'wof:country': 'DE',
+      'wof:label': 'Lake County',
+      'name:eng_x_preferred': [ 'Lake' ],
+    }, function(){
+      t.deepEqual( mock._calls.set.length, 1 );
+      t.deepEqual( mock._calls.set[0][1].names, { eng: [ 'Lake' ] } );
+      t.end();
+    });
+  });
+};
+
 module.exports.set_edges = function(test, util) {
 
   test( 'no hierarchy', function(t) {


### PR DESCRIPTION
note: this code is branched off https://github.com/pelias/placeholder/pull/7, please merge that PR first

this was requested by @dianashk, the idea here is that (only for the USA) if we have a `wof:label` then we would like to favor that property over the `name:eng_x_preferred` property.

this solves the `Lake vs. Lake County` problem, both forms will be indexed but the `wof:label` property will be returned.