### PR TITLE
abbr: correctly import abbreviations for dependencies

### DIFF
--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -156,7 +156,7 @@ function getPopulation( wof ) {
 // logic copied from: pelias/whosonfirst src/components/extractFields.js (since modified)
 function getAbbreviation( wof ) {
   if( 'country' === wof['wof:placetype'] || 'dependency' === wof['wof:placetype'] ) {
-    return wof['wof:country_alpha3'] || wof['wof:abbreviation'];
+    return wof['wof:country_alpha3'] || wof['ne:iso_a3'];
   } else if( wof['wof:abbreviation'] ) {
     return wof['wof:abbreviation'];
   }

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -153,10 +153,10 @@ function getPopulation( wof ) {
 }
 
 // abbreviations and ISO codes
-// logic copied from: pelias/whosonfirst src/components/extractFields.js
+// logic copied from: pelias/whosonfirst src/components/extractFields.js (since modified)
 function getAbbreviation( wof ) {
   if( 'country' === wof['wof:placetype'] || 'dependency' === wof['wof:placetype'] ) {
-    return wof['wof:country_alpha3'];
+    return wof['wof:country_alpha3'] || wof['wof:abbreviation'];
   } else if( wof['wof:abbreviation'] ) {
     return wof['wof:abbreviation'];
   }

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -335,14 +335,16 @@ module.exports.getAbbreviation = function(test, util) {
   test( 'country/dependency', function(t) {
     t.equal( undefined, wof.getAbbreviation({ 'wof:placetype': 'country' }) );
     t.equal( undefined, wof.getAbbreviation({ 'wof:placetype': 'dependency' }) );
-    t.equal( 'TEST2', wof.getAbbreviation({
+
+    t.equal( undefined, wof.getAbbreviation({
       'wof:placetype': 'country',
       'wof:abbreviation': 'TEST2'
     }));
-    t.equal( 'TEST2', wof.getAbbreviation({
+    t.equal( undefined, wof.getAbbreviation({
       'wof:placetype': 'dependency',
       'wof:abbreviation': 'TEST2'
     }));
+
     t.equal( 'TEST', wof.getAbbreviation({
       'wof:placetype': 'country',
       'wof:country_alpha3': 'TEST',
@@ -352,17 +354,41 @@ module.exports.getAbbreviation = function(test, util) {
       'wof:placetype': 'dependency',
       'wof:country_alpha3': 'TEST',
       'wof:abbreviation': 'TEST2'
+    }));
+
+    t.equal( 'TEST', wof.getAbbreviation({
+      'wof:placetype': 'country',
+      'ne:iso_a3': 'TEST',
+      'wof:abbreviation': 'TEST2'
+    }));
+    t.equal( 'TEST', wof.getAbbreviation({
+      'wof:placetype': 'dependency',
+      'ne:iso_a3': 'TEST',
+      'wof:abbreviation': 'TEST2'
+    }));
+
+    t.equal( 'TEST', wof.getAbbreviation({
+      'wof:placetype': 'country',
+      'wof:country_alpha3': 'TEST',
+      'ne:iso_a3': 'TEST2',
+      'wof:abbreviation': 'TEST3'
+    }));
+    t.equal( 'TEST', wof.getAbbreviation({
+      'wof:placetype': 'dependency',
+      'wof:country_alpha3': 'TEST',
+      'ne:iso_a3': 'TEST2',
+      'wof:abbreviation': 'TEST3'
     }));
     t.end();
   });
 
   test( 'wof:abbreviation', function(t) {
     t.equal( 'TEST2', wof.getAbbreviation({
-      'wof:country_alpha3': 'TEST',
+      'ne:iso_a3': 'TEST',
       'wof:abbreviation': 'TEST2'
     }));
     t.equal( 'TEST2', wof.getAbbreviation({
-      'wof:country_alpha3': 'TEST',
+      'ne:iso_a3': 'TEST',
       'wof:abbreviation': 'TEST2'
     }));
     t.end();

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -335,11 +335,11 @@ module.exports.getAbbreviation = function(test, util) {
   test( 'country/dependency', function(t) {
     t.equal( undefined, wof.getAbbreviation({ 'wof:placetype': 'country' }) );
     t.equal( undefined, wof.getAbbreviation({ 'wof:placetype': 'dependency' }) );
-    t.equal( undefined, wof.getAbbreviation({
+    t.equal( 'TEST2', wof.getAbbreviation({
       'wof:placetype': 'country',
       'wof:abbreviation': 'TEST2'
     }));
-    t.equal( undefined, wof.getAbbreviation({
+    t.equal( 'TEST2', wof.getAbbreviation({
       'wof:placetype': 'dependency',
       'wof:abbreviation': 'TEST2'
     }));


### PR DESCRIPTION
correctly import abbreviations for dependencies, fixes the `missing dependency_a` issue.

tested via a local `npm run build`:

```javascript
"id": 85633729,
"name": "Puerto Rico",
"abbr": "PRI",                      <-
"placetype": "dependency",
"population": 3971020,
```