### PR TITLE
Cast numeric string values

### DIFF
--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -20,7 +20,7 @@ function insertWofRecord( wof, next ){
     abbr: getAbbreviation( wof ),
     placetype: wof['wof:placetype'],
     population: getPopulation( wof ),
-    popularity: parseInt( wof['misc:photo_sum'], 10 ) || undefined,
+    popularity: wof['misc:photo_sum'],
     lineage: wof['wof:hierarchy'],
     geom: {
       area: wof['geom:area'],
@@ -30,6 +30,15 @@ function insertWofRecord( wof, next ){
     },
     names: {}
   };
+
+  // --- cast strings to numeric types ---
+  // note: sometimes numeric properties in WOF can be encoded as strings.
+
+  if( 'string' === typeof doc.population ){ doc.population = parseInt( doc.population, 10 ); }
+  if( 'string' === typeof doc.popularity ){ doc.popularity = parseInt( doc.popularity, 10 ); }
+  if( 'string' === typeof doc.geom.area ){ doc.geom.area = parseFloat( doc.geom.area ); }
+  if( 'string' === typeof doc.geom.lat ){ doc.geom.lat = parseFloat( doc.geom.lat ); }
+  if( 'string' === typeof doc.geom.lon ){ doc.geom.lon = parseFloat( doc.geom.lon ); }
 
   // --- tokens ---
 

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -177,6 +177,17 @@ module.exports.store_population = function(test, util) {
       t.end();
     });
   });
+
+  test( 'population: calls function - as string', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': '1',
+      'mz:population': '999'
+    }, function(){
+      t.deepEqual( mock._calls.set[0][1].population, 999);
+      t.end();
+    });
+  });
 };
 
 module.exports.store_popularity = function(test, util) {
@@ -261,6 +272,17 @@ module.exports.store_geom = function(test, util) {
     });
   });
 
+  test( 'geom: area defined - as string', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': '1',
+      'geom:area': '999'
+    }, function(){
+      t.deepEqual( mock._calls.set[0][1].geom.area, 999);
+      t.end();
+    });
+  });
+
   test( 'geom: no bbox', function(t) {
     var mock = new Mock();
     mock.insertWofRecord({
@@ -316,11 +338,34 @@ module.exports.store_geom = function(test, util) {
     });
   });
 
+  test( 'geom: lat prefer label - as string', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': '1',
+      'lbl:latitude': '1',
+      'geom:latitude': 2
+    }, function(){
+      t.deepEqual( mock._calls.set[0][1].geom.lat, 1);
+      t.end();
+    });
+  });
+
   test( 'geom: lat no label', function(t) {
     var mock = new Mock();
     mock.insertWofRecord({
       'wof:id': '1',
       'geom:latitude': 2
+    }, function(){
+      t.deepEqual( mock._calls.set[0][1].geom.lat, 2);
+      t.end();
+    });
+  });
+
+  test( 'geom: lat no label - as string', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': '1',
+      'geom:latitude': '2'
     }, function(){
       t.deepEqual( mock._calls.set[0][1].geom.lat, 2);
       t.end();
@@ -349,11 +394,34 @@ module.exports.store_geom = function(test, util) {
     });
   });
 
+  test( 'geom: lon prefer label - as string', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': '1',
+      'lbl:longitude': '1',
+      'geom:longitude': 2
+    }, function(){
+      t.deepEqual( mock._calls.set[0][1].geom.lon, 1);
+      t.end();
+    });
+  });
+
   test( 'geom: lon no label', function(t) {
     var mock = new Mock();
     mock.insertWofRecord({
       'wof:id': '1',
       'geom:longitude': 2
+    }, function(){
+      t.deepEqual( mock._calls.set[0][1].geom.lon, 2);
+      t.end();
+    });
+  });
+
+  test( 'geom: lon no label - as string', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord({
+      'wof:id': '1',
+      'geom:longitude': '2'
     }, function(){
       t.deepEqual( mock._calls.set[0][1].geom.lon, 2);
       t.end();


### PR DESCRIPTION
note this is branched off https://github.com/pelias/placeholder/pull/13 please merge that PR first and rebase.

see this commit https://github.com/pelias/placeholder/commit/a3591c1061e93a2fa96051535aa9ee143485ae9f for a review friendly diff

this PR ensures that badly encoded numeric values are correctly parsed to their expected type.

see https://github.com/pelias/placeholder/issues/6 for a more complete description of the issue

fixes https://github.com/pelias/placeholder/issues/6