### PR TITLE
analysis: better support for apostrophe s

### DIFF
--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -28,13 +28,13 @@ function normalize( input ){
   var synonyms = [ input ];
 
   // synonymous representations of hyphens and apostrophes
-  if( input.match(/['-]+/) ){
+  if( input.match(/['‘’-]+/) ){
     synonyms = synonyms.map( function( synonym ){
-      return synonym.replace(/['-]+/g, '');
+      return synonym.replace(/['‘’-]+/g, '');
     }).concat( synonyms.map( function( synonym ){
       return synonym
-        .replace(/('s)/g, '')
-        .replace(/['-]+/g, ' ');
+        .replace(/(['‘’]s)/g, '')
+        .replace(/['‘’-]+/g, ' ');
     }));
   }
 

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -29,10 +29,13 @@ function normalize( input ){
 
   // synonymous representations of hyphens and apostrophes
   if( input.match(/['-]+/) ){
-    synonyms = [
-      input.replace(/['-]+/g,''),
-      input.replace(/['-]+/g,' '),
-    ];
+    synonyms = synonyms.map( function( synonym ){
+      return synonym.replace(/['-]+/g, '');
+    }).concat( synonyms.map( function( synonym ){
+      return synonym
+        .replace(/('s)/g, '')
+        .replace(/['-]+/g, ' ');
+    }));
   }
 
   // simple replacements

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -34,7 +34,7 @@
 101748283 Madrid, Spain
 101748417 Helsinki, Finland
 101750367 London, United Kingdom
-85632335 St. George's, Grenada
+890451719 St. George's, Grenada
 1091680781 Cayenne, French Guiana
 85681223 St Peter Port, Guernsey
 421168965 Accra, Ghana

--- a/test/lib/analysis.js
+++ b/test/lib/analysis.js
@@ -9,6 +9,8 @@ module.exports.normalize = function(test, common) {
 
   // apostrophe s
   assert( 'St. George\'s', [ 'st georges', 'st george' ] );
+  assert( 'St. George\‘s', [ 'st georges', 'st george' ] );
+  assert( 'St. George\’s', [ 'st georges', 'st george' ] );
 
   // Punctuation substitutions
   assert( 'Straße', [ 'strasse' ] );
@@ -44,6 +46,9 @@ module.exports.tokenize = function(test, common) {
   assert( 'Foo  Bar', [[ 'foo', 'bar' ]] );
   assert( 'Foo,,Bar', [[ 'foo', 'bar' ]] );
   assert( 'Foo\'\'Bar', [[ 'foobar' ], [ 'foo', 'bar' ]] );
+  assert( 'Foo‘‘Bar', [[ 'foobar' ], [ 'foo', 'bar' ]] );
+  assert( 'Foo’’Bar', [[ 'foobar' ], [ 'foo', 'bar' ]] );
+  assert( 'Foo\'’’Bar', [[ 'foobar' ], [ 'foo', 'bar' ]] );
   assert( 'Foo""Bar', [[ 'foo', 'bar' ]] );
 
   // not a delimeter

--- a/test/lib/analysis.js
+++ b/test/lib/analysis.js
@@ -7,6 +7,9 @@ module.exports.normalize = function(test, common) {
   // Germanic substitutions
   assert( 'Schöneberg', [ 'schoneberg', 'schoeneberg' ] );
 
+  // apostrophe s
+  assert( 'St. George\'s, Grenada', [ 'st georges grenada', 'st george grenada' ] );
+
   // Punctuation substitutions
   assert( 'Straße', [ 'strasse' ] );
   assert( 'Jǿ œ̆', [ 'jo oe' ] );

--- a/test/lib/analysis.js
+++ b/test/lib/analysis.js
@@ -8,7 +8,7 @@ module.exports.normalize = function(test, common) {
   assert( 'Schöneberg', [ 'schoneberg', 'schoeneberg' ] );
 
   // apostrophe s
-  assert( 'St. George\'s, Grenada', [ 'st georges grenada', 'st george grenada' ] );
+  assert( 'St. George\'s', [ 'st georges', 'st george' ] );
 
   // Punctuation substitutions
   assert( 'Straße', [ 'strasse' ] );


### PR DESCRIPTION
better support for 'apostrophe s'.

I noticed that `St. George's` was being tokenized as:

```
[ 'st georges', 'st george s' ]
```

this PR still tokenizes it in the singular and plural forms but drops the extra 's' token:

```
[ 'st georges', 'st george' ]
```