### PR TITLE
bugfix: use 'iso:country' instead of 'wof:country'

### DIFF
--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -96,7 +96,7 @@ function insertWofRecord( wof, next ){
   }
 
   // In the USA we would like to favor the 'wof:label' property over the 'name:eng_x_preferred' property.
-  if( 'US' === wof['wof:country'] && wof['wof:label'] ){
+  if( 'US' === wof['iso:country'] && wof['wof:label'] ){
     doc.names.eng = [ wof['wof:label'] ];
   }
 

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -771,7 +771,8 @@ module.exports.usa_english_name_override_with_label = function(test, util) {
     var mock = new Mock();
     mock.insertWofRecord({
       'wof:id': 102085121,
-      'wof:country': 'US',
+      'iso:country': 'US',
+      'wof:name': 'Test',
       'wof:label': 'Lake County',
       'name:eng_x_preferred': [ 'Lake' ],
     }, function(){
@@ -798,7 +799,7 @@ module.exports.usa_english_name_override_with_label = function(test, util) {
     var mock = new Mock();
     mock.insertWofRecord({
       'wof:id': 102085121,
-      'wof:country': 'US',
+      'iso:country': 'US',
       'name:eng_x_preferred': [ 'Lake' ],
     }, function(){
       t.deepEqual( mock._calls.set.length, 1 );
@@ -811,7 +812,7 @@ module.exports.usa_english_name_override_with_label = function(test, util) {
     var mock = new Mock();
     mock.insertWofRecord({
       'wof:id': 102085121,
-      'wof:country': 'US',
+      'iso:country': 'US',
       'wof:label': 'Lake County'
     }, function(){
       t.deepEqual( mock._calls.set.length, 1 );


### PR DESCRIPTION
bugfix: use 'iso:country' instead of 'wof:country'

after much confusion I figured out that the property name was wrong :P