### PR TITLE
analysis: remove city as official designations

### DIFF
--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -64,12 +64,13 @@ function normalize( input ){
   }
 
   // synonymous representations of official designations
-  if( input.match(/county/i) ){
+  if( input.match(/county|city/i) ){
     synonyms = synonyms.concat(
       synonyms.map( function( synonym ){
         return synonym
           .replace(/^county\s(of\s)?(.*)$/gi, '$2')
-          .replace(/^(.*)\scounty$/gi, '$1');
+          .replace(/^(.*)\scounty$/gi, '$1')
+          .replace(/^city\sof(?!\s?the)\s?(.*)$/gi, '$1');
       })
     );
   }
@@ -90,7 +91,7 @@ function normalize( input ){
   })
   // remove duplicate synonyms
   .filter( function( synonym, pos, self ){
-    return self.indexOf(synonym) == pos;
+    return self.indexOf(synonym) === pos;
   });
 }
 

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -64,14 +64,12 @@ function normalize( input ){
   }
 
   // synonymous representations of official designations
-  if( input.match(/county|city/i) ){
+  if( input.match(/county/i) ){
     synonyms = synonyms.concat(
       synonyms.map( function( synonym ){
         return synonym
           .replace(/^county\s(of\s)?(.*)$/gi, '$2')
-          .replace(/^(.*)\scounty$/gi, '$1')
-          .replace(/^city\s(of\s)?(.*)$/gi, '$2')
-          .replace(/^(.*)\scity$/gi, '$1');
+          .replace(/^(.*)\scounty$/gi, '$1');
       })
     );
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "pre-commit": [
     "lint",
     "validate",
-    "test",
-    "check-dependencies"
+    "check-dependencies",
+    "test"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cli": "node cmd/cli.js",
     "lint": "jshint .",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "check-dependencies": "node_modules/.bin/npm-check --production",
+    "check-dependencies": "node_modules/.bin/npm-check --skip-unused --production",
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "validate": "npm ls",
     "travis": "npm run check-dependencies && npm test"
@@ -33,6 +33,7 @@
     "express": "^4.15.2",
     "lodash": "^4.17.4",
     "lower-case": "^1.1.4",
+    "npm-check": "^5.4.4",
     "remove-accents": "^0.4.0",
     "sorted-intersect": "^0.1.4",
     "split2": "^2.1.1",
@@ -45,7 +46,6 @@
     "tape": "^4.6.3",
     "istanbul": "^0.4.2",
     "jshint": "^2.5.6",
-    "npm-check": "git://github.com/orangejulius/npm-check.git#disable-update-check",
     "precommit-hook": "^3.0.0",
     "semantic-release": "^6.3.2"
   },

--- a/test/lib/analysis.js
+++ b/test/lib/analysis.js
@@ -49,14 +49,17 @@ module.exports.normalize = function(test, common) {
 
   assert( 'City', [ 'city' ] );
   assert( 'City London', [ 'city london' ] );
-  assert( 'City of London', [ 'city of london' ] );
+  assert( 'City of London', [ 'city of london', 'london' ] );
   assert( 'London City', [ 'london city' ] );
   assert( 'City Salt Lake', [ 'city salt lake' ] );
-  assert( 'City of Salt Lake', [ 'city of salt lake' ] );
+  assert( 'City of Salt Lake', [ 'city of salt lake', 'salt lake' ] );
   assert( 'New York City', [ 'new york city' ] );
   assert( 'City New York', [ 'city new york' ] );
-  assert( 'City of New York', [ 'city of new york' ] );
+  assert( 'City of New York', [ 'city of new york', 'new york' ] );
   assert( 'New York City', [ 'new york city' ] );
+
+  assert( 'City of the Sun', [ 'city of the sun' ] );
+  assert( 'City of Sun', [ 'city of sun', 'sun' ] );
 };
 
 module.exports.tokenize = function(test, common) {

--- a/test/lib/analysis.js
+++ b/test/lib/analysis.js
@@ -48,12 +48,15 @@ module.exports.normalize = function(test, common) {
   assert( 'Two Words County', [ 'two words county', 'two words' ] );
 
   assert( 'City', [ 'city' ] );
-  assert( 'City London', [ 'city london', 'london' ] );
-  assert( 'City of London', [ 'city of london', 'london' ] );
-  assert( 'London City', [ 'london city', 'london' ] );
-  assert( 'City Salt Lake', [ 'city salt lake', 'salt lake' ] );
-  assert( 'City of Salt Lake', [ 'city of salt lake', 'salt lake' ] );
-  assert( 'Salt Lake City', [ 'salt lake city', 'salt lake' ] );
+  assert( 'City London', [ 'city london' ] );
+  assert( 'City of London', [ 'city of london' ] );
+  assert( 'London City', [ 'london city' ] );
+  assert( 'City Salt Lake', [ 'city salt lake' ] );
+  assert( 'City of Salt Lake', [ 'city of salt lake' ] );
+  assert( 'New York City', [ 'new york city' ] );
+  assert( 'City New York', [ 'city new york' ] );
+  assert( 'City of New York', [ 'city of new york' ] );
+  assert( 'New York City', [ 'new york city' ] );
 };
 
 module.exports.tokenize = function(test, common) {


### PR DESCRIPTION
this PR is a suggestion, it can be merged or discarded, I am not fussed :)

I saw in our latest acceptance test run that `New York City` is now being lost among the other matches for `New York`.

the reason is that  `new york city` is now tokenized as: `[ 'new york city', 'new york' ]` and so it now also matches the non-city places such as The State of New York (on `'new york'`).

whereas before it was parsed as `[ 'new york city' ]` and so didn't return the state etc.

I'm thinking it might be an idea to reverse this change, I don't think the sorting rules will be able to fix it, so this might be the better of two evils?

note that the inverse is fine either way as the city record also contains other fields with the term `'new york'`, so typing `new york` will return BOTH the city and the state, I'm just suggesting that typing `new york city` should ONLY return the city.

> also see `mexico city` which comes further down the list, as `mexico` the country is more populous.

discuss!