### PR TITLE
cmd: extract: add placetype filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ docker-compose up -d
 - jq 1.5+ must be installed
     - on ubuntu: `sudo apt-get install jq`
     - on mac: `brew install jq`
-- Who's on First data download with **admin data only** (not tested or recommended to run with postalcodes and venues)
+- Who's on First data download
     - use the download script in [pelias/whosonfirst](https://github.com/pelias/whosonfirst#downloading-the-data)
 
 ### steps

--- a/cmd/placetype.filter
+++ b/cmd/placetype.filter
@@ -1,0 +1,1 @@
+"wof:placetype":\s*"\(continent\|country\|dependency\|disputed\|macroregion\|region\|macrocounty\|county\|localadmin\|locality\|borough\|macrohood\|neighbourhood\)"

--- a/cmd/wof_extract.sh
+++ b/cmd/wof_extract.sh
@@ -35,10 +35,10 @@ fi
 # filter records by placetype
 # removing any file names from the stream whose body does not match the pattern
 function placetypeFilter {
-  while IFS= read -r file; do
-    grep --files-with-match -f "$DIR/placetype.filter" "$file";
+  while IFS= read -r FILENAME; do
+    grep --files-with-match -f "${DIR}/placetype.filter" "${FILENAME}";
   done
 }
 
 # extract only the json properies from each file (eg: excluding zs:*)
-find "${WOF_DIR}" -type f -name '*.geojson' | placetypeFilter | ${XARGS_CMD} ${JQ_BIN} -c -M -f "$DIR/jq.filter";
+find "${WOF_DIR}" -type f -name '*.geojson' | placetypeFilter | ${XARGS_CMD} ${JQ_BIN} -c -M -f "${DIR}/jq.filter";

--- a/cmd/wof_extract.sh
+++ b/cmd/wof_extract.sh
@@ -32,5 +32,13 @@ if [[ -f "${PARALLEL_BIN}" || -x "${PARALLEL_BIN}" ]]; then
   XARGS_CMD='parallel --no-notice --group --keep-order --jobs +0';
 fi
 
+# filter records by placetype
+# removing any file names from the stream whose body does not match the pattern
+function placetypeFilter {
+  while IFS= read -r file; do
+    grep --files-with-match -f "$DIR/placetype.filter" "$file";
+  done
+}
+
 # extract only the json properies from each file (eg: excluding zs:*)
-find "${WOF_DIR}" -type f -name '*.geojson' | ${XARGS_CMD} ${JQ_BIN} -c -M -f "$DIR/jq.filter";
+find "${WOF_DIR}" -type f -name '*.geojson' | placetypeFilter | ${XARGS_CMD} ${JQ_BIN} -c -M -f "$DIR/jq.filter";


### PR DESCRIPTION
this additional stream function will filter records which do not match a specified placetype.

this allows us to have a mix of venues and postcodes in the data and still only extract admin records.