### PR TITLE
remove redundant synonymous groupings

### DIFF
--- a/prototype/tokenize.js
+++ b/prototype/tokenize.js
@@ -63,7 +63,25 @@ module.exports.tokenize = function( input ){
   }, this);
 
   // console.log( '[', queries.join( ', ' ), ']' );
-  return queries.filter( function( query ){
+
+  // remove empty arrays
+  queries = queries.filter( function( query ){
     return !!query.length;
   });
+
+  // synonymous groupings
+  // this removes queries such as `[ B, C ]` where another group such as
+  // `[ A, B, C ]` exists.
+  // see: https://github.com/pelias/placeholder/issues/28
+  queries = queries.filter( function( query, i ){
+    for( var j=0; j<queries.length; j++ ){
+      if( j === i ){ continue; }
+      if( _.isEqual( query, queries[j].slice( -query.length ) ) ){
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return queries;
 };

--- a/test/prototype/tokenize.js
+++ b/test/prototype/tokenize.js
@@ -16,6 +16,11 @@ module.exports.tokenize = function(test, util) {
   // duplicates
   assert('lancaster lancaster pa', [['lancaster', 'lancaster', 'pa']]);
 
+  // synonymous groupings
+  // see: https://github.com/pelias/placeholder/issues/28
+  assert('Le Cros-d’Utelle, France', [['le cros','d','utelle','france']]);
+  assert('luxemburg luxemburg', [['luxemburg', 'luxemburg']]); // does not remove duplicate tokens
+
   // ambiguous parses
   // @note: these are the glorious future:
 


### PR DESCRIPTION
fixes https://github.com/pelias/placeholder/issues/28

in some cases the tokenizer can return groups such as:

```
[
 [ C ],
 [ A, B, C ]
]

or...

[
 [ B, C ],
 [ A, B, C ]
]
```

this can result in a less granular result being returned next to a more granular result from the same lineage (as per the example in the linked issue).

the algorithm checks each array from the right hand side to ensure that there is no other group which also contains the same elements in it's rightmost elements.

kind of hard to explain, see the issue for a clearer example.