### PR TITLE
README point to API config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ placeholder > id 85772991
 
 ---
 
+## configuration for pelias API
+
+While Placeholder can be used as a stand-alone application or included with other geographic software / search engines, it is designed for the [Pelias geocoder](https://github.com/pelias/pelias).
+
+To connect Placeholder service to the Pelias API, [configure the pelias config file](https://github.com/pelias/api#pelias-config) with the port that placeholder is running on.
+
+---
+
 ## tests
 
 ### run the test suite


### PR DESCRIPTION
Direct users to the pelias/api README for instructions on how to connect placeholder service with the API

Fixes #32 