### PR TITLE
Fix CircleCI code to skip builds on greenkeeper branches

### DIFF
--- a/.circleci/docker.sh
+++ b/.circleci/docker.sh
@@ -7,7 +7,7 @@ DOCKER_REPOSITORY="pelias"
 DOCKER_PROJECT="${DOCKER_REPOSITORY}/${CIRCLE_PROJECT_REPONAME}"
 
 # skip builds on greenkeeper branches
-if [ "${CIRCLE_BRANCH##greenkeeper}" ]; then
+if [[ -z "${CIRCLE_BRANCH##*greenkeeper*}" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
This will only skip greenkeeper branches, instead of all of them.

Connects https://github.com/pelias/dockerfiles/issues/21