### PR TITLE
introduce language blacklist

### DIFF
--- a/config/language/blacklist.js
+++ b/config/language/blacklist.js
@@ -1,0 +1,16 @@
+
+/**
+  This blacklist lists all the language codes we exclude for import in to placeholder.
+
+  The whosonfirst dataset contains many disused and rarely-used languages which
+  can cause issues when the source data has been machine transiliterated.
+
+  The list is non-exhaustive and was originally sourced from wikipedia and various
+  online sources, I aimed to include the most commonly spoken languages worldwide.
+
+  If you feel a language code is wrong or missing, please feel free to edit this file.
+**/
+
+// Enawene Nawe language
+// https://en.wikipedia.org/wiki/Enawene_Nawe_language
+module.exports.unk = '';

--- a/config/language/blacklist.js
+++ b/config/language/blacklist.js
@@ -6,7 +6,7 @@
   can cause issues when the source data has been machine transiliterated.
 
   The list is non-exhaustive and was originally sourced from wikipedia and various
-  online sources, I aimed to include the most commonly spoken languages worldwide.
+  online sources, I aimed to only include the least commonly spoken languages.
 
   If you feel a language code is wrong or missing, please feel free to edit this file.
 **/

--- a/config/language/blacklist.js
+++ b/config/language/blacklist.js
@@ -14,3 +14,7 @@
 // Enawene Nawe language
 // https://en.wikipedia.org/wiki/Enawene_Nawe_language
 module.exports.unk = '';
+
+// Volapük
+// https://en.wikipedia.org/wiki/Volap%C3%BCk
+module.exports.vol = '';

--- a/config/language/whitelist.js
+++ b/config/language/whitelist.js
@@ -1,0 +1,272 @@
+/**
+  This whitelist lists all the language codes we accept for import in to placeholder.
+
+  The whosonfirst dataset contains many disused and rarely-used languages which
+  can cause issues when the source data has been machine transiliterated.
+
+  The list is non-exhaustive and was originally sourced from wikipedia and various
+  online sources, I aimed to include the most commonly spoken languages worldwide.
+
+  If you feel a language code is wrong or missing, please feel free to edit this file.
+**/
+
+// Chinese - 汉语/漢語 Hànyǔ or 中文 Zhōngwén
+module.exports.chi = '';
+module.exports.zho = '';
+module.exports.cdo = '';
+module.exports.cjy = '';
+module.exports.cmn = '';
+module.exports.cpx = '';
+module.exports.czh = '';
+module.exports.czo = '';
+module.exports.gan = '';
+module.exports.hak = '';
+module.exports.hsn = '';
+module.exports.mnp = '';
+module.exports.nan = '';
+module.exports.wuu = '';
+module.exports.yue = '';
+module.exports.och = '';
+module.exports.ltc = '';
+module.exports.lzh = '';
+
+// Spanish - español ("Spanish") and castellano ("Castilian")
+module.exports.esp = '';
+module.exports.spa = '';
+
+// English
+module.exports.eng = '';
+
+// Arabic - العربية
+module.exports.ara = '';
+module.exports.arq = '';
+module.exports.aao = '';
+module.exports.bbz = '';
+module.exports.abv = '';
+module.exports.shu = '';
+module.exports.acy = '';
+module.exports.adf = '';
+module.exports.avl = '';
+module.exports.arz = '';
+module.exports.afb = '';
+module.exports.ayh = '';
+module.exports.acw = '';
+module.exports.ayl = '';
+module.exports.acm = '';
+module.exports.ary = '';
+module.exports.ars = '';
+module.exports.apc = '';
+module.exports.ayp = '';
+module.exports.acx = '';
+module.exports.aec = '';
+module.exports.ayn = '';
+module.exports.ssh = '';
+module.exports.ajp = '';
+module.exports.arb = '';
+module.exports.apb = '';
+module.exports.pga = '';
+module.exports.acq = '';
+module.exports.abh = '';
+module.exports.aeb = '';
+module.exports.auz = '';
+
+// Hindi - मानक हिन्दी - Mānak Hindī
+module.exports.hin = '';
+
+// Bengali - বাংলা - Bangla
+module.exports.ben = '';
+
+// Portuguese - português
+module.exports.por = '';
+
+// Russian - ру́сский язы́к - russkij jazyk
+module.exports.rus = '';
+
+// Japanese - 日本語 - Nihongo
+module.exports.jpn = '';
+
+// Punjabi
+module.exports.pan = '';
+module.exports.pnb = '';
+
+// German - Deutsch
+module.exports.ger = '';
+module.exports.deu = '';
+module.exports.gmh = '';
+module.exports.goh = '';
+module.exports.gct = '';
+module.exports.bar = '';
+module.exports.cim = '';
+module.exports.geh = '';
+module.exports.ksh = '';
+module.exports.nds = '';
+module.exports.sli = '';
+module.exports.ltz = '';
+module.exports.vmf = '';
+module.exports.mhn = '';
+module.exports.pfl = '';
+module.exports.pdc = '';
+module.exports.pdt = '';
+module.exports.swg = '';
+module.exports.gsw = '';
+module.exports.uln = '';
+module.exports.sxu = '';
+module.exports.wae = '';
+module.exports.wep = '';
+module.exports.hrx = '';
+module.exports.yec = '';
+
+// Javanese
+module.exports.jav = '';
+module.exports.jvn = '';
+module.exports.jas = '';
+module.exports.osi = '';
+module.exports.tes = '';
+module.exports.kaw = '';
+
+// Malay
+module.exports.msa = '';
+module.exports.kxd = '';
+module.exports.ind = '';
+module.exports.zsm = '';
+module.exports.jax = '';
+module.exports.meo = '';
+module.exports.kvr = '';
+module.exports.xmm = '';
+module.exports.min = '';
+module.exports.mui = '';
+module.exports.zmi = '';
+module.exports.max = '';
+module.exports.mfa = '';
+
+// Lahnda
+module.exports.lah = '';
+module.exports.hnd = '';
+module.exports.hno = '';
+module.exports.jat = '';
+module.exports.phr = '';
+module.exports.skr = '';
+module.exports.xhe = '';
+
+// Telugu
+module.exports.tel = '';
+
+// Vietnamese
+module.exports.vie = '';
+
+// Marathi
+module.exports.mar = '';
+module.exports.omr = '';
+
+// French - le français
+module.exports.fra = '';
+module.exports.fre = '';
+
+// Korean - 한국어 - Hangugeo
+module.exports.kor = '';
+module.exports.jje = '';
+module.exports.okm = '';
+module.exports.oko = '';
+
+// Tamil
+module.exports.tam = '';
+module.exports.oty = '';
+module.exports.ptq = '';
+
+// Italian
+module.exports.ita = '';
+
+// Urdu
+module.exports.urd = '';
+
+// Tai-Kadai - ภาษาไต - p̣hās̛̄ā tay
+module.exports.tai = '';
+
+// Thai
+module.exports.tha = '';
+
+// Tagalog
+module.exports.tgl = '';
+module.exports.fil = '';
+
+// Swedish
+module.exports.swe = '';
+
+// Turkish
+module.exports.tur = '';
+
+// Gujarati
+module.exports.guj = '';
+
+// Persian
+module.exports.fas = '';
+module.exports.pes = '';
+module.exports.prs = '';
+module.exports.tgk = '';
+module.exports.aiq = '';
+module.exports.bhh = '';
+module.exports.haz = '';
+module.exports.jpr = '';
+module.exports.phv = '';
+module.exports.deh = '';
+module.exports.jdt = '';
+module.exports.ttt = '';
+
+// Polish
+module.exports.pol = '';
+module.exports.szl = '';
+
+// Pashto
+module.exports.pus = '';
+module.exports.pst = '';
+module.exports.pbu = '';
+module.exports.pbt = '';
+module.exports.wne = '';
+
+// Kannada
+module.exports.kan = '';
+
+// Malayalam
+module.exports.mal = '';
+
+// Sundanese
+module.exports.sun = '';
+
+// Hausa
+module.exports.hau = '';
+
+// Odia
+module.exports.ori = '';
+module.exports.ory = '';
+module.exports.spv = '';
+module.exports.bpv = '';
+module.exports.ort = '';
+module.exports.dso = '';
+
+// Romanian
+module.exports.rum = '';
+module.exports.ron = '';
+
+// Dutch
+module.exports.dut = '';
+module.exports.nld = '';
+module.exports.vls = '';
+module.exports.zea = '';
+
+// Hungarian
+module.exports.hun = '';
+module.exports.ohu = '';
+
+// Greek
+module.exports.gre = '';
+module.exports.ell = '';
+module.exports.grc = '';
+module.exports.cpg = '';
+module.exports.gmy = '';
+module.exports.pnt = '';
+module.exports.tsd = '';
+module.exports.yej = '';
+
+// Czech
+module.exports.cze = '';
+module.exports.ces = '';

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -1,7 +1,9 @@
 
 // plugin for whosonfirst
 var _ = require('lodash'),
-    analysis = require('../lib/analysis');
+    dir = require('require-dir'),
+    analysis = require('../lib/analysis'),
+    language = dir('../config/language');
 
 // insert a wof record in to index
 function insertWofRecord( wof, next ){
@@ -85,9 +87,15 @@ function insertWofRecord( wof, next ){
     // names: preferred|colloquial|variant|unknown
     var match = attr.match(/^name:([a-z]{3})_x_(preferred|colloquial|variant)$/);
     if( match ){
+
+      // skip languages in the blacklist, see config file for more info
+      if( language.blacklist.hasOwnProperty( match[1] ) ){ continue; }
+
+      // index each alternative name
       for( var n in wof[ attr ] ){
         analysis.normalize( wof[ attr ][ n ] ).forEach( addToken );
       }
+
       // doc - only store 'preferred' strings
       if( match[2] === 'preferred' ){
         doc.names[ match[1] ] = wof[ attr ];

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
   Mock object used for all tests in this file
 
   The mock stores all function calls in an internal Array for
-  later inspection during tests, this let's us know how many times
+  later inspection during tests, this lets us know how many times
   each function was called and which arguments were provided.
 **/
 var Mock = function(){
@@ -733,11 +733,11 @@ module.exports.add_names = function(test, util) {
   test( 'tokens: supported name fields', function(t) {
     var mock = new Mock();
     mock.insertWofRecord(params({
-      'name:foo_x_preferred': [ 'A', 'B' ],
-      'name:foo_x_colloquial': [ 'C', 'D' ],
-      'name:foo_x_variant': [ 'E', 'F' ],
-      'name:foo_x_unknown': [ 'G', 'H' ], // we don't import the 'unknown' language type
-      'name:foo_x_foobar': [ 'I', 'J' ], // made-up name
+      'name:eng_x_preferred': [ 'A', 'B' ],
+      'name:eng_x_colloquial': [ 'C', 'D' ],
+      'name:eng_x_variant': [ 'E', 'F' ],
+      'name:eng_x_unknown': [ 'G', 'H' ], // we don't import the 'unknown' language type
+      'name:eng_x_foobar': [ 'I', 'J' ], // made-up name
     }), function(){
       t.deepEqual( mock._calls.addToken.length, 6 );
       t.deepEqual( mock._calls.addToken[0][3], [ 'a' ] );
@@ -753,15 +753,15 @@ module.exports.add_names = function(test, util) {
   test( 'store: supported name fields', function(t) {
     var mock = new Mock();
     mock.insertWofRecord(params({
-      'name:foo_x_preferred': [ 'A', 'B' ],
-      'name:foo_x_colloquial': [ 'C', 'D' ],
-      'name:foo_x_variant': [ 'E', 'F' ],
-      'name:foo_x_unknown': [ 'G', 'H' ], // we don't import the 'unknown' language type
-      'name:foo_x_foobar': [ 'I', 'J' ], // made-up name
-      'name:bar_x_preferred': [ 'Y', 'Z' ],
+      'name:deu_x_preferred': [ 'A', 'B' ],
+      'name:deu_x_colloquial': [ 'C', 'D' ],
+      'name:deu_x_variant': [ 'E', 'F' ],
+      'name:deu_x_unknown': [ 'G', 'H' ], // we don't import the 'unknown' language type
+      'name:deu_x_foobar': [ 'I', 'J' ], // made-up name
+      'name:ita_x_preferred': [ 'Y', 'Z' ],
     }), function(){
       t.deepEqual( mock._calls.set.length, 1 );
-      t.deepEqual( mock._calls.set[0][1].names, { foo: [ 'A', 'B' ], bar: [ 'Y', 'Z' ] });
+      t.deepEqual( mock._calls.set[0][1].names, { deu: [ 'A', 'B' ], ita: [ 'Y', 'Z' ] });
       t.end();
     });
   });
@@ -781,6 +781,65 @@ module.exports.add_names = function(test, util) {
     }), function(){
       t.deepEqual( mock._calls.set.length, 1 );
       t.deepEqual( mock._calls.set[0][1].names, {});
+      t.end();
+    });
+  });
+
+  // // langauge whitelist - included
+  // test( 'store: accept languages in whitelist', function(t) {
+  //   var mock = new Mock();
+  //   mock.insertWofRecord(params({
+  //     'name:chi_x_preferred': [ 'A' ],
+  //     'name:zho_x_preferred': [ 'A' ],
+  //     'name:esp_x_preferred': [ 'A' ],
+  //     'name:eng_x_preferred': [ 'A' ],
+  //     'name:ara_x_preferred': [ 'A' ],
+  //     'name:hin_x_preferred': [ 'A' ],
+  //     'name:ben_x_preferred': [ 'A' ],
+  //     'name:por_x_preferred': [ 'A' ],
+  //     'name:rus_x_preferred': [ 'A' ],
+  //     'name:jpn_x_preferred': [ 'A' ],
+  //     'name:ger_x_preferred': [ 'A' ],
+  //     'name:deu_x_preferred': [ 'A' ],
+  //     'name:jav_x_preferred': [ 'A' ],
+  //     'name:lah_x_preferred': [ 'A' ],
+  //     'name:tel_x_preferred': [ 'A' ],
+  //     'name:vie_x_preferred': [ 'A' ],
+  //     'name:mar_x_preferred': [ 'A' ],
+  //     'name:fra_x_preferred': [ 'A' ],
+  //     'name:fre_x_preferred': [ 'A' ],
+  //     'name:kor_x_preferred': [ 'A' ],
+  //     'name:tam_x_preferred': [ 'A' ],
+  //     'name:ita_x_preferred': [ 'A' ],
+  //     'name:urd_x_preferred': [ 'A' ],
+  //     'name:tai_x_preferred': [ 'A' ],
+  //     'name:tgl_x_preferred': [ 'A' ],
+  //   }), function(){
+  //     t.deepEqual( mock._calls.addToken.length, 25 );
+  //     t.end();
+  //   });
+  // });
+  //
+  // // langauge whitelist - excluded
+  // test( 'store: reject languages not in whitelist', function(t) {
+  //   var mock = new Mock();
+  //   mock.insertWofRecord(params({
+  //     'name:foo_x_preferred': [ 'A' ],
+  //     'name:ron_x_preferred': [ 'Ușă' ],
+  //     'name:unk_x_preferred': [ 'Kreuzberg' ],
+  //   }), function(){
+  //     t.deepEqual( mock._calls.addToken.length, 0 );
+  //     t.end();
+  //   });
+  // });
+
+  // langauge blacklist - excluded
+  test( 'store: reject languages in blacklist', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord(params({
+      'name:unk_x_preferred': [ 'Kreuzberg' ],
+    }), function(){
+      t.deepEqual( mock._calls.addToken.length, 0 );
       t.end();
     });
   });

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -838,6 +838,7 @@ module.exports.add_names = function(test, util) {
     var mock = new Mock();
     mock.insertWofRecord(params({
       'name:unk_x_preferred': [ 'Kreuzberg' ],
+      'name:vol_x_preferred': [ 'Example' ],
     }), function(){
       t.deepEqual( mock._calls.addToken.length, 0 );
       t.end();

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -785,7 +785,7 @@ module.exports.add_names = function(test, util) {
     });
   });
 
-  // // langauge whitelist - included
+  // // language whitelist - included
   // test( 'store: accept languages in whitelist', function(t) {
   //   var mock = new Mock();
   //   mock.insertWofRecord(params({
@@ -820,7 +820,7 @@ module.exports.add_names = function(test, util) {
   //   });
   // });
   //
-  // // langauge whitelist - excluded
+  // // language whitelist - excluded
   // test( 'store: reject languages not in whitelist', function(t) {
   //   var mock = new Mock();
   //   mock.insertWofRecord(params({
@@ -833,7 +833,7 @@ module.exports.add_names = function(test, util) {
   //   });
   // });
 
-  // langauge blacklist - excluded
+  // language blacklist - excluded
   test( 'store: reject languages in blacklist', function(t) {
     var mock = new Mock();
     mock.insertWofRecord(params({


### PR DESCRIPTION
this PR started off as a language whitelist but turned into a language blacklist instead :)

I've included the whitelist file in this PR as it took a fair bit of work and we might switch to using it at a later date.

For now, only one language is excluded, the [Enawene Nawe language](https://en.wikipedia.org/wiki/Enawene_Nawe_language) which is a language spoken by ~350 people.
Enawene Nawe translations have caused problems on two notable occasions:
- [York](https://whosonfirst.mapzen.com/spelunker/id/85973605/) is assigned `unk_x_variant: New York`
- [Krucemburk](https://whosonfirst.mapzen.com/spelunker/id/101826419/) is assigned `unk_x_variant: Kreuzberg`

This PR simply excludes any language fields which are enumerated in the blacklist, those fields are not stored for search or for display.

[edit] I also added [Volapük](https://en.wikipedia.org/wiki/Volap%C3%BCk) which has caused issues in the past.