### PR TITLE
Add empire ocean marinearea

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_install:
 before_script:
   - npm prune
   - mkdir data
-  - curl -s http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > data/graph.json;
-  - curl -s http://pelias-data.s3.amazonaws.com/placeholder/store.sqlite3.gz | gunzip > data/store.sqlite3;
+  - curl -s http://pelias-data.s3.amazonaws.com/placeholder/archive/$(date +%Y-%m-%d)/graph.json.gz | gunzip > data/graph.json;
+  - curl -s http://pelias-data.s3.amazonaws.com/placeholder/archive/$(date +%Y-%m-%d)/store.sqlite3.gz | gunzip > data/store.sqlite3;
 after_success:
   - npm run semantic-release
 branches:

--- a/README.md
+++ b/README.md
@@ -249,3 +249,17 @@ if you have push access you can upload your new image to dockerhub:
 ```bash
 $ docker push mapzen/pelias-placeholder
 ```
+
+---
+
+### uploading a new build to s3
+
+this section is applicable to mapzen employees only and requires s3 credentials and the `aws` command to be installed and configured prior to running.
+
+other organizations may elect to change the bucket name in the config and utilize the same script.
+
+the script takes care of creating a date stamped archive and promoting the most recent build to the root of the bucket (with a public ACL).
+
+```bash
+$ ./cmd/s3_upload.sh
+```

--- a/README.md
+++ b/README.md
@@ -262,4 +262,18 @@ the script takes care of creating a date stamped archive and promoting the most 
 
 ```bash
 $ ./cmd/s3_upload.sh
+
+--- gzipping data files ---
+--- uploading archive ---
+upload: data/graph.json.gz to s3://pelias-data/placeholder/archive/2017-09-29/graph.json.gz
+upload: data/store.sqlite3.gz to s3://pelias-data/placeholder/archive/2017-09-29/store.sqlite3.gz
+upload: data/wof.extract.gz to s3://pelias-data/placeholder/archive/2017-09-29/wof.extract.gz
+--- list remote archive ---
+2017-09-29 14:52:20   15.3 MiB graph.json.gz
+2017-09-29 14:52:33   46.6 MiB store.sqlite3.gz
+2017-09-29 14:53:08   53.8 MiB wof.extract.gz
+
+> would you like to promote this build to production (yes/no)?
+no
+you did not answer yes, the build was not promoted to production
 ```

--- a/cmd/placetype.filter
+++ b/cmd/placetype.filter
@@ -1,1 +1,1 @@
-"wof:placetype":\s*"\(continent\|country\|dependency\|disputed\|macroregion\|region\|macrocounty\|county\|localadmin\|locality\|borough\|macrohood\|neighbourhood\)"
+"wof:placetype":\s*"\(ocean\|continent\|marinearea\|empire\|country\|dependency\|disputed\|macroregion\|region\|macrocounty\|county\|localadmin\|locality\|borough\|macrohood\|neighbourhood\)"

--- a/cmd/s3_upload.sh
+++ b/cmd/s3_upload.sh
@@ -2,35 +2,42 @@
 set -euo pipefail
 
 # directory of this file
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
-DATA_DIR=${PLACEHOLDER_DATA:-"${DIR}/../data"};
-BUCKET='s3://pelias-data/placeholder/';
-TODAY=`date +%Y-%m-%d`;
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DATA_DIR=${PLACEHOLDER_DATA:-"${DIR}/../data"}
+BUCKET='s3://pelias-data/placeholder'
+TODAY=`date +%Y-%m-%d`
 
-echo '--- gzip data files ---';
+echo '--- gzipping data files ---'
 if type pigz >/dev/null
   then
-    pigz -k -c --best "${DATA_DIR}/graph.json" > "${DATA_DIR}/graph.json.gz";
-    pigz -k -c --best "${DATA_DIR}/store.sqlite3" > "${DATA_DIR}/store.sqlite3.gz";
-    pigz -k -c --best "${DATA_DIR}/wof.extract" > "${DATA_DIR}/wof.extract.gz";
+    pigz -k -c --best "${DATA_DIR}/graph.json" > "${DATA_DIR}/graph.json.gz"
+    pigz -k -c --best "${DATA_DIR}/store.sqlite3" > "${DATA_DIR}/store.sqlite3.gz"
+    pigz -k -c --best "${DATA_DIR}/wof.extract" > "${DATA_DIR}/wof.extract.gz"
   else
-    gzip -c --best "${DATA_DIR}/graph.json" > "${DATA_DIR}/graph.json.gz";
-    gzip -c --best "${DATA_DIR}/store.sqlite3" > "${DATA_DIR}/store.sqlite3.gz";
-    gzip -c --best "${DATA_DIR}/wof.extract" > "${DATA_DIR}/wof.extract.gz";
+    gzip -c --best "${DATA_DIR}/graph.json" > "${DATA_DIR}/graph.json.gz"
+    gzip -c --best "${DATA_DIR}/store.sqlite3" > "${DATA_DIR}/store.sqlite3.gz"
+    gzip -c --best "${DATA_DIR}/wof.extract" > "${DATA_DIR}/wof.extract.gz"
 fi
 
-echo '--- upload files to s3 ---';
-aws s3 cp "${DATA_DIR}/graph.json.gz" "${BUCKET}" --region us-east-1 --acl public-read;
-aws s3 cp "${DATA_DIR}/store.sqlite3.gz" "${BUCKET}" --region us-east-1 --acl public-read;
-aws s3 cp "${DATA_DIR}/wof.extract.gz" "${BUCKET}" --region us-east-1 --acl public-read;
+echo '--- uploading archive ---'
+aws s3 cp "${DATA_DIR}/graph.json.gz" "${BUCKET}/archive/${TODAY}/graph.json.gz" --region us-east-1 --acl public-read
+aws s3 cp "${DATA_DIR}/store.sqlite3.gz" "${BUCKET}/archive/${TODAY}/store.sqlite3.gz" --region us-east-1 --acl public-read
+aws s3 cp "${DATA_DIR}/wof.extract.gz" "${BUCKET}/archive/${TODAY}/wof.extract.gz" --region us-east-1 --acl public-read
 
-echo '--- create archive ---';
-aws s3 cp "${BUCKET}graph.json.gz" "${BUCKET}archive/${TODAY}/graph.json.gz" --region us-east-1 --acl public-read;
-aws s3 cp "${BUCKET}store.sqlite3.gz" "${BUCKET}archive/${TODAY}/store.sqlite3.gz" --region us-east-1 --acl public-read;
-aws s3 cp "${BUCKET}wof.extract.gz" "${BUCKET}archive/${TODAY}/wof.extract.gz" --region us-east-1 --acl public-read;
+echo '--- list remote archive ---'
+aws s3 ls --human-readable "${BUCKET}/archive/${TODAY}/"
 
-echo '--- list files ---';
-aws s3 ls --human-readable "${BUCKET}";
+echo -e "\n> would you like to promote this build to production (yes/no)?"
+read answer
 
-echo '--- list archive files ---';
-aws s3 ls --human-readable "${BUCKET}archive/${TODAY}/";
+if [ "$answer" == "yes" || "$answer" == "y" ]; then
+  echo '--- promoting build to production ---'
+  aws s3 cp "${BUCKET}/archive/${TODAY}/graph.json.gz" "${BUCKET}/graph.json.gz" --region us-east-1 --acl public-read
+  aws s3 cp "${BUCKET}/archive/${TODAY}/store.sqlite3.gz" "${BUCKET}/store.sqlite3.gz" --region us-east-1 --acl public-read
+  aws s3 cp "${BUCKET}/archive/${TODAY}/wof.extract.gz" "${BUCKET}/wof.extract.gz" --region us-east-1 --acl public-read
+
+  echo '--- list remote production files ---'
+  aws s3 ls --human-readable "${BUCKET}/"
+else
+  echo 'you did not answer yes, the build was not promoted to production'
+fi

--- a/cmd/s3_upload.sh
+++ b/cmd/s3_upload.sh
@@ -30,7 +30,7 @@ aws s3 ls --human-readable "${BUCKET}/archive/${TODAY}/"
 echo -e "\n> would you like to promote this build to production (yes/no)?"
 read answer
 
-if [ "$answer" == "yes" || "$answer" == "y" ]; then
+if [ "$answer" == "yes" ] || [ "$answer" == "y" ]; then
   echo '--- promoting build to production ---'
   aws s3 cp "${BUCKET}/archive/${TODAY}/graph.json.gz" "${BUCKET}/graph.json.gz" --region us-east-1 --acl public-read
   aws s3 cp "${BUCKET}/archive/${TODAY}/store.sqlite3.gz" "${BUCKET}/store.sqlite3.gz" --region us-east-1 --acl public-read

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -47,58 +47,63 @@ function insertWofRecord( wof, next ){
   // convenience function with $id bound as first argument
   var addToken = this.graph.addToken.bind( this.graph, id );
 
-  // add 'wof:label'
-  analysis.normalize( wof['wof:label'] ).forEach( addToken );
+  // disable adding tokens to the index for the 'empire' placetype.
+  // this ensures empire records are not retrieved via search.
+  if( 'empire' !== doc.placetype ){
 
-  // add 'wof:name'
-  analysis.normalize( wof['wof:name'] ).forEach( addToken );
+    // add 'wof:label'
+    analysis.normalize( wof['wof:label'] ).forEach( addToken );
 
-  // add 'wof:abbreviation'
-  analysis.normalize( wof['wof:abbreviation'] ).forEach( addToken );
+    // add 'wof:name'
+    analysis.normalize( wof['wof:name'] ).forEach( addToken );
 
-  // add 'ne:abbrev'
-  // analysis.normalize( wof['ne:abbrev'] ).forEach( addToken );
+    // add 'wof:abbreviation'
+    analysis.normalize( wof['wof:abbreviation'] ).forEach( addToken );
 
-  // fields specific to countries & dependencies
-  if( 'country' === doc.placetype || 'dependency' === doc.placetype ) {
-    if( wof['iso:country'] && wof['iso:country'] !== 'XX' ){
+    // add 'ne:abbrev'
+    // analysis.normalize( wof['ne:abbrev'] ).forEach( addToken );
 
-      // add 'ne:iso_a2'
-      analysis.normalize( wof['ne:iso_a2'] ).forEach( addToken );
+    // fields specific to countries & dependencies
+    if( 'country' === doc.placetype || 'dependency' === doc.placetype ) {
+      if( wof['iso:country'] && wof['iso:country'] !== 'XX' ){
 
-      // add 'ne:iso_a3'
-      analysis.normalize( wof['ne:iso_a3'] ).forEach( addToken );
+        // add 'ne:iso_a2'
+        analysis.normalize( wof['ne:iso_a2'] ).forEach( addToken );
 
-      // add 'wof:country'
-      // warning: eg. FR for 'French Guiana'
-      // analysis.normalize( wof['wof:country'] ).forEach( addToken );
+        // add 'ne:iso_a3'
+        analysis.normalize( wof['ne:iso_a3'] ).forEach( addToken );
 
-      // add 'iso:country'
-      analysis.normalize( wof['iso:country'] ).forEach( addToken );
+        // add 'wof:country'
+        // warning: eg. FR for 'French Guiana'
+        // analysis.normalize( wof['wof:country'] ).forEach( addToken );
 
-      // add 'wof:country_alpha3'
-      analysis.normalize( wof['wof:country_alpha3'] ).forEach( addToken );
-    }
-  }
+        // add 'iso:country'
+        analysis.normalize( wof['iso:country'] ).forEach( addToken );
 
-  // add 'name:*'
-  for( var attr in wof ){
-    // https://github.com/whosonfirst/whosonfirst-names
-    // names: preferred|colloquial|variant|unknown
-    var match = attr.match(/^name:([a-z]{3})_x_(preferred|colloquial|variant)$/);
-    if( match ){
-
-      // skip languages in the blacklist, see config file for more info
-      if( language.blacklist.hasOwnProperty( match[1] ) ){ continue; }
-
-      // index each alternative name
-      for( var n in wof[ attr ] ){
-        analysis.normalize( wof[ attr ][ n ] ).forEach( addToken );
+        // add 'wof:country_alpha3'
+        analysis.normalize( wof['wof:country_alpha3'] ).forEach( addToken );
       }
+    }
 
-      // doc - only store 'preferred' strings
-      if( match[2] === 'preferred' ){
-        doc.names[ match[1] ] = wof[ attr ];
+    // add 'name:*'
+    for( var attr in wof ){
+      // https://github.com/whosonfirst/whosonfirst-names
+      // names: preferred|colloquial|variant|unknown
+      var match = attr.match(/^name:([a-z]{3})_x_(preferred|colloquial|variant)$/);
+      if( match ){
+
+        // skip languages in the blacklist, see config file for more info
+        if( language.blacklist.hasOwnProperty( match[1] ) ){ continue; }
+
+        // index each alternative name
+        for( var n in wof[ attr ] ){
+          analysis.normalize( wof[ attr ][ n ] ).forEach( addToken );
+        }
+
+        // doc - only store 'preferred' strings
+        if( match[2] === 'preferred' ){
+          doc.names[ match[1] ] = wof[ attr ];
+        }
       }
     }
   }

--- a/server/demo/index.html
+++ b/server/demo/index.html
@@ -58,7 +58,7 @@
 
       var order = [
         'venue', 'address', 'building', 'campus', 'microhood', 'neighbourhood', 'macrohood', 'burough', 'postalcode',
-        'locality', 'metro area', 'localadmin', 'county', 'macrocounty', 'region', 'macroregion', 'country', 'empire', 'continent', 'ocean', 'planet'
+        'locality', 'metro area', 'localadmin', 'county', 'macrocounty', 'region', 'macroregion', 'marinearea', 'country', 'empire', 'continent', 'ocean', 'planet'
       ];
 
       function exec( text ){

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -845,6 +845,18 @@ module.exports.add_names = function(test, util) {
     });
   });
 
+  // do not store tokens for the 'empire' placetype
+  test( 'empire tokens excluded', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord(params({
+      'wof:placetype': 'empire',
+      'name:eng_x_preferred': [ 'A', 'B' ]
+    }), function(){
+      t.deepEqual( mock._calls.addToken.length, 0 );
+      t.end();
+    });
+  });
+
 };
 
 // In the USA we would like to favor the 'wof:label' property over the 'name:eng_x_preferred' property.


### PR DESCRIPTION
This PR is composed of 2 distinct parts:

- add `empire`, `ocean` & `marinearea` placetypes
- refactor the way our builds are uploaded & published

And also includes the latest data as of this morning:

- data updated

### add new placetypes

This is pretty straight-forward with the exception of `empire`, I added a new code block to disable the tokens for `empire` records being saved.

The effect of this is that, when you search, you will not be able to retrieve `empire` records, you will however still be able to see them listed in the hierarchy of other records and their translations will also be available for language services.

### refactor s3_upload

I added some docs in the readme about how to use this command. It is responsible for zipping-up and uploading the data to our s3 bucket.

Prior to this PR, the script would first promote the code to production and then archive it, I reversed the order of operations so it archives first, then it prompts you if you would like to promote the build to production yes/no.

The idea here is that, when developing new builds, you can upload them to a datestamped archive, Travis will now pull from that archive to run the tests, then, pending review and Travis passing, you can promote the build to production by either rerunning the command and typing `yes` or by manually executing s3 commands to copy files from the archive to the bucket root.