### PR TITLE
server: fix for CPU detection

### DIFF
--- a/server/http.js
+++ b/server/http.js
@@ -28,7 +28,7 @@ const logger = require('pelias-logger').get('placeholder');
 
 // select the amount of cpus we will use
 const envCpus = parseInt( process.env.CPUS, 10 );
-const cpus = Math.min( Math.max( envCpus, 1 ), os.cpus().length );
+const cpus = Math.min( Math.max( envCpus || Infinity, 1 ), os.cpus().length );
 
 // optionally override port/host using env var
 var PORT = process.env.PORT || 3000;


### PR DESCRIPTION
PR https://github.com/pelias/placeholder/pull/64 introduced a bug where failing to specify the `CPUS` environment variable started the server in single-threaded mode:

```bash
$ node server/http.js 
cpus NaN
```

This PR fixes the bug so the default behaviour is now to start the server using all available CPUs:

```bash
$ node server/http.js 
cpus 8

CPUS=-1 node server/http.js 
cpus 1

CPUS=0 node server/http.js 
cpus 8

CPUS=2 node server/http.js 
cpus 2

CPUS=999 node server/http.js 
cpus 8

CPUS= node server/http.js 
cpus 8

CPUS=test node server/http.js 
cpus 8
```