### PR TITLE
improved awareness of placetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,39 @@ the demo is also able to serve responses in different languages by providing the
 ... etc.
 ```
 
+### filtering by placetype
+
+the `/parser/search` endpoint accepts a `?placetype=xxx` parameter which can be used to control the placetype of records which are returned.
+
+the API does not provide any performance benefits, it is simply a convenience API to filter by a whitelist.
+
+you may specify multiple placetypes using a comma to separate them, such as `?placetype=xxx,yyy`, these are matched as OR conditions. eg: (xxx OR yyy)
+
+for example:
+
+the query `search?text=luxemburg` will return results for the `country`, `region`, `locality` etc.
+
+you can use the placetype filter to control which records are returned:
+
+```
+# all matching results
+search?text=luxemburg
+
+# only return matching country records
+search?text=luxemburg&placetype=country
+
+# return matching country or region records
+search?text=luxemburg&placetype=country,region
+```
+
+### live mode (BETA)
+
+the `/parser/search` endpoint accepts a `?mode=live` parameter pair which can be used to enable an autocomplete-style API.
+
+in this mode the final token of each input text is considered as 'incomplete', meaning that the user has potentially only typed part of a token.
+
+this mode is currently in BETA, the interface and behaviour may change over time.
+
 ---
 
 ## run the interactive shell

--- a/lib/TokenIndex.js
+++ b/lib/TokenIndex.js
@@ -18,8 +18,8 @@ TokenIndex.prototype.reset = function(){
   this.db.exec('CREATE INDEX IF NOT EXISTS lineage_cover_idx ON lineage(id, pid);');
 
   this.db.exec('DROP TABLE IF EXISTS tokens;');
-  this.db.exec('CREATE TABLE tokens( id INTEGER, lang STRING, tag STRING, token STRING );');
-  this.db.exec('CREATE INDEX IF NOT EXISTS tokens_cover_idx ON tokens(id, lang, tag);');
+  this.db.exec('CREATE TABLE tokens( id INTEGER, layer STRING, lang STRING, tag STRING, token STRING );');
+  this.db.exec('CREATE INDEX IF NOT EXISTS tokens_cover_idx ON tokens(id, layer, lang, tag);');
   this.db.exec('CREATE INDEX IF NOT EXISTS tokens_token_idx ON tokens(token);');
 
   // FTS table options
@@ -41,9 +41,10 @@ TokenIndex.prototype.checkSchema = function(){
   ]);
   Database.assertSchema(this.db, 'tokens', [
     { cid: 0, name: 'id', type: 'INTEGER', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 1, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 2, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 3, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
+    { cid: 1, name: 'layer', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 2, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 3, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 4, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
   ]);
   Database.assertSchema(this.db, 'fulltext', [
     { cid: 0, name: 'token', type: '', notnull: 0, dflt_value: null, pk: 0 }
@@ -76,12 +77,13 @@ TokenIndex.prototype.setTokens = function( id, tokens, cb ){
 
   // create prepared statement
   var stmt = this.prepare(
-    'INSERT INTO tokens ( id, lang, tag, token ) VALUES ( $id, $lang, $tag, $token )'
+    'INSERT INTO tokens ( id, layer, lang, tag, token ) VALUES ( $id, $layer, $lang, $tag, $token )'
   );
 
   try {
     tokens.forEach( token => stmt.run({
       id: id,
+      layer: token.layer,
       lang: token.lang,
       tag: token.tag,
       token: token.body

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -52,36 +52,36 @@ function insertWofRecord( wof, next ){
   if( 'empire' !== doc.placetype ){
 
     // add 'wof:label'
-    tokens.push({ lang: 'und', tag: 'label', body: wof['wof:label'] });
+    tokens.push({ lang: 'und', layer: doc.placetype, tag: 'label', body: wof['wof:label'] });
 
     // add 'wof:name'
-    tokens.push({ lang: 'und', tag: 'label', body: wof['wof:name'] });
+    tokens.push({ lang: 'und', layer: doc.placetype, tag: 'label', body: wof['wof:name'] });
 
     // add 'wof:abbreviation'
-    tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:abbreviation'] });
+    tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['wof:abbreviation'] });
 
     // add 'ne:abbrev'
-    // tokens.push({ lang: 'und', body: wof['ne:abbrev'] });
+    // tokens.push({ lang: 'und', layer: doc.placetype, body: wof['ne:abbrev'] });
 
     // fields specific to countries & dependencies
     if( 'country' === doc.placetype || 'dependency' === doc.placetype ) {
       if( wof['iso:country'] && wof['iso:country'] !== 'XX' ){
 
         // add 'ne:iso_a2'
-        tokens.push({ lang: 'und', tag: 'abbr', body: wof['ne:iso_a2'] });
+        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['ne:iso_a2'] });
 
         // add 'ne:iso_a3'
-        tokens.push({ lang: 'und', tag: 'abbr', body: wof['ne:iso_a3'] });
+        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['ne:iso_a3'] });
 
         // add 'wof:country'
         // warning: eg. FR for 'French Guiana'
-        // tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:country'] });
+        // tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['wof:country'] });
 
         // add 'iso:country'
-        tokens.push({ lang: 'und', tag: 'abbr', body: wof['iso:country'] });
+        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['iso:country'] });
 
         // add 'wof:country_alpha3'
-        tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:country_alpha3'] });
+        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['wof:country_alpha3'] });
       }
     }
 
@@ -98,6 +98,7 @@ function insertWofRecord( wof, next ){
         // index each alternative name
         for( var n in wof[ attr ] ){
           tokens.push({
+            layer: doc.placetype,
             lang: match[1],
             tag: match[2],
             body: wof[ attr ][ n ]
@@ -145,7 +146,7 @@ function insertWofRecord( wof, next ){
   // normalize tokens
   tokens = tokens.reduce(( res, token ) => {
     analysis.normalize( token.body ).forEach( norm => {
-      res.push({ lang: token.lang, tag: token.tag, body: norm });
+      res.push({ lang: token.lang, layer: token.layer, tag: token.tag, body: norm });
     });
     return res;
   }, []);

--- a/server/routes/_util.js
+++ b/server/routes/_util.js
@@ -1,0 +1,18 @@
+
+// in express, if you pass query params like this `?param[]=value`
+// then the type of the param is Array and the code may be expecting a string.
+// this convenience function allows either form to be used.
+function arrayParam( param ){
+  var res = [];
+
+  // accept param as array. eg: param[]=value
+  if( Array.isArray( param ) ){ res = param; }
+
+  // accept param as string. eg: param=value
+  if( 'string' === typeof param ){ res = param.split(','); }
+
+  // trim strings and remove empty elements
+  return res.map(a => a.trim()).filter(a => a.length);
+}
+
+module.exports.arrayParam = arrayParam;

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -1,4 +1,5 @@
 
+const _ = require('lodash');
 const PARTIAL_TOKEN_SUFFIX = require('../../lib/analysis').PARTIAL_TOKEN_SUFFIX;
 
 module.exports = function( req, res ){
@@ -8,6 +9,14 @@ module.exports = function( req, res ){
 
   // input text
   var text = req.query.text || '';
+
+  // placetype filter
+  var filter = {
+      placetype: ( req.query.placetype || '' )
+                    .split(',')
+                    .map(a => a.trim())
+                    .filter(a => a.length)
+  };
 
   // live mode (autocomplete-style search)
   // we append a byte indicating the last word is potentially incomplete.
@@ -35,6 +44,11 @@ module.exports = function( req, res ){
     ph.store.getMany( ids, function( err, results ){
       if( err ){ return res.status(500).send(err); }
       if( !results || !results.length ){ return res.status(200).send([]); }
+
+      // placetype filter
+      if( Array.isArray( filter.placetype ) && filter.placetype.length ){
+        results = results.filter(res => _.includes( filter.placetype, res.placetype ));
+      }
 
       // get a list of parent ids
       const parentIds = getParentIds( results );

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -1,5 +1,6 @@
 
 const _ = require('lodash');
+const util = require('./_util');
 const PARTIAL_TOKEN_SUFFIX = require('../../lib/analysis').PARTIAL_TOKEN_SUFFIX;
 
 module.exports = function( req, res ){
@@ -11,12 +12,7 @@ module.exports = function( req, res ){
   var text = req.query.text || '';
 
   // placetype filter
-  var filter = {
-      placetype: ( req.query.placetype || '' )
-                    .split(',')
-                    .map(a => a.trim())
-                    .filter(a => a.length)
-  };
+  var filter = { placetype: util.arrayParam( req.query.placetype ) };
 
   // live mode (autocomplete-style search)
   // we append a byte indicating the last word is potentially incomplete.

--- a/test/lib/TokenIndex.js
+++ b/test/lib/TokenIndex.js
@@ -18,7 +18,7 @@ module.exports.reset = function(test, common) {
   test('reset', function(t) {
     var db = new TokenIndex();
     db.open('/tmp/db', { test: true, reset: true });
-    
+
     // ensure table has been created
     var sql = 'PRAGMA table_info(lineage)';
     t.deepEqual( db.prepare(sql).all(), [
@@ -30,9 +30,10 @@ module.exports.reset = function(test, common) {
     sql = 'PRAGMA table_info(tokens)';
     t.deepEqual( db.prepare(sql).all(), [
       { cid: 0, name: 'id', type: 'INTEGER', notnull: 0, dflt_value: null, pk: 0 },
-      { cid: 1, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-      { cid: 2, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-      { cid: 3, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
+      { cid: 1, name: 'layer', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+      { cid: 2, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+      { cid: 3, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+      { cid: 4, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
     ]);
 
     // ensure table has been created
@@ -43,13 +44,13 @@ module.exports.reset = function(test, common) {
 
     // ensure fts table has been created with the correct options
     sql = 'select * from sqlite_master where type="table" and name="fulltext"';
-    const expected = 
+    const expected =
       'CREATE VIRTUAL TABLE fulltext USING fts5( token, ' + [
       `tokenize="unicode61 remove_diacritics 0 tokenchars '_'"`,
       `prefix='1 2 3 4 5 6 7 8 9 10 11 12'`,
       'columnsize=0'
     ].join(', ') + ')';
-    
+
     t.deepEqual( db.prepare(sql).get().sql, expected );
     t.end();
   });
@@ -175,8 +176,8 @@ module.exports.setTokens = function(test, common) {
       // ensure rows have been created
       const sql = 'SELECT * FROM tokens';
       t.deepEqual( db.prepare(sql).all(), [
-        { id: 100, lang: 'en', tag: 'abbr', token: 'test1' },
-        { id: 100, lang: 'fr', tag: 'variant', token: 'test2' }
+        { id: 100, layer: null, lang: 'en', tag: 'abbr', token: 'test1' },
+        { id: 100, layer: null, lang: 'fr', tag: 'variant', token: 'test2' }
       ]);
 
     });

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -619,7 +619,7 @@ module.exports.add_token = function(test, util) {
     }), function(){
       t.deepEqual( mock._calls.setTokens[0][0], 1 );
       t.deepEqual( mock._calls.setTokens[0][1], [
-        { lang: 'und', tag: 'abbr', body: 'example' }
+        { lang: 'und', layer: undefined, tag: 'abbr', body: 'example' }
       ]);
       t.end();
     });
@@ -633,8 +633,8 @@ module.exports.add_token = function(test, util) {
     }), function(){
       t.deepEqual( mock._calls.setTokens[0][0], 1 );
       t.deepEqual( mock._calls.setTokens[0][1], [
-        { lang: 'und', tag: 'label', body: 'example' },
-        { lang: 'und', tag: 'label', body: 'example2' }
+        { lang: 'und', layer: undefined, tag: 'label', body: 'example' },
+        { lang: 'und', layer: undefined, tag: 'label', body: 'example2' }
       ]);
       t.end();
     });
@@ -663,10 +663,10 @@ module.exports.add_token = function(test, util) {
       'wof:country_alpha3': 'EXP'
     }), function(){
       t.deepEqual( mock._calls.setTokens[0][1], [
-        { lang: 'und', tag: 'abbr', body: 'ex' },
-        { lang: 'und', tag: 'abbr', body: 'exa' },
-        { lang: 'und', tag: 'abbr', body: 'ep' },
-        { lang: 'und', tag: 'abbr', body: 'exp' }
+        { lang: 'und', layer: 'country', tag: 'abbr', body: 'ex' },
+        { lang: 'und', layer: 'country', tag: 'abbr', body: 'exa' },
+        { lang: 'und', layer: 'country', tag: 'abbr', body: 'ep' },
+        { lang: 'und', layer: 'country', tag: 'abbr', body: 'exp' }
       ]);
       t.end();
     });
@@ -695,10 +695,10 @@ module.exports.add_token = function(test, util) {
       'wof:country_alpha3': 'EXP'
     }), function(){
       t.deepEqual( mock._calls.setTokens[0][1], [
-        { lang: 'und', tag: 'abbr', body: 'ex' },
-        { lang: 'und', tag: 'abbr', body: 'exa' },
-        { lang: 'und', tag: 'abbr', body: 'ep' },
-        { lang: 'und', tag: 'abbr', body: 'exp' }
+        { lang: 'und', layer: 'dependency', tag: 'abbr', body: 'ex' },
+        { lang: 'und', layer: 'dependency', tag: 'abbr', body: 'exa' },
+        { lang: 'und', layer: 'dependency', tag: 'abbr', body: 'ep' },
+        { lang: 'und', layer: 'dependency', tag: 'abbr', body: 'exp' }
       ]);
       t.end();
     });
@@ -726,7 +726,7 @@ module.exports.add_token = function(test, util) {
       'ne:abbrev': 'TEST2'
     }), function(){
       t.deepEqual( mock._calls.setTokens[0][1], [
-        { lang: 'und', tag: 'abbr', body: 'ep' }
+        { lang: 'und', layer: 'dependency', tag: 'abbr', body: 'ep' }
       ]);
       t.end();
     });
@@ -753,12 +753,12 @@ module.exports.add_names = function(test, util) {
       'name:eng_x_foobar': [ 'I', 'J' ], // made-up name
     }), function(){
       t.deepEqual( mock._calls.setTokens[0][1], [
-        { lang: 'eng', tag: 'preferred', body: 'a' },
-        { lang: 'eng', tag: 'preferred', body: 'b' },
-        { lang: 'eng', tag: 'colloquial', body: 'c' },
-        { lang: 'eng', tag: 'colloquial', body: 'd' },
-        { lang: 'eng', tag: 'variant', body: 'e' },
-        { lang: 'eng', tag: 'variant', body: 'f' }
+        { lang: 'eng', layer: undefined, tag: 'preferred', body: 'a' },
+        { lang: 'eng', layer: undefined, tag: 'preferred', body: 'b' },
+        { lang: 'eng', layer: undefined, tag: 'colloquial', body: 'c' },
+        { lang: 'eng', layer: undefined, tag: 'colloquial', body: 'd' },
+        { lang: 'eng', layer: undefined, tag: 'variant', body: 'e' },
+        { lang: 'eng', layer: undefined, tag: 'variant', body: 'f' }
       ]);
       t.end();
     });

--- a/test/server/routes/_util.js
+++ b/test/server/routes/_util.js
@@ -1,0 +1,15 @@
+
+var util = require('../../../server/routes/_util');
+
+module.exports.arrayParam = function(test, common) {
+  test('arrayParam', function(t) {
+    t.deepEqual( util.arrayParam(undefined), [], 'undefined' );
+    t.deepEqual( util.arrayParam(null), [], 'null' );
+    t.deepEqual( util.arrayParam(''), [], 'empty' );
+    t.deepEqual( util.arrayParam([]), [], 'empty array' );
+    t.deepEqual( util.arrayParam(['a ', ' b']), ['a','b'], 'array' );
+    t.deepEqual( util.arrayParam(' test '), ['test'], 'simple string' );
+    t.deepEqual( util.arrayParam(' test, foo '), ['test','foo'], 'delimited string' );
+    t.end();
+  });
+};

--- a/test/units.js
+++ b/test/units.js
@@ -15,6 +15,7 @@ var tests = [
   './prototype/io',
   './prototype/tokenize',
   './prototype/query',
+  './server/routes/_util.js',
 ];
 
 // test runner


### PR DESCRIPTION
this PR refactors the code to provide better functionality around the `placetype` property.

- add the `placetype` field to the tokens table for each token, this will allow us (in the future) to return more detailed information regarding the hierarchy of each matched token.
- add a `?placetype=xxx,yyy` filter to the search HTTP endpoint, allowing users to filter which placetypes are returned (requested by @trescube)

tested locally, all tests passing.