### PR TITLE
additional placetypes

### DIFF
--- a/cmd/download_extract.sh
+++ b/cmd/download_extract.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # placetypes to download and extract
-PLACETYPES=( 'neighbourhood' 'macrohood' 'borough' 'locality' 'localadmin' 'county' 'macrocounty' 'region'
-  'macroregion' 'disputed' 'dependency' 'country' 'empire' 'marinearea' 'continent' 'ocean' )
+PLACETYPES=( 'campus' 'microhood' 'neighbourhood' 'macrohood' 'borough' 'locality' 'localadmin' 'county' 'macrocounty' 'region'
+  'macroregion' 'disputed' 'dependency' 'country' 'empire' 'marinearea' 'continent' 'ocean' 'planet' )
 
 # download and extract fields from contents of tar
 function extract {


### PR DESCRIPTION
TDC, add some missing placetypes.

`cmd/download_extract.sh`: this convenience script was added recently to handle downloading bundles and running the extraction without having to first decompress the files to disk.

the command is not currently used in our production build pipeline (we use the download script in the `pelias/whosonfirst` repo), as such it would not have any effect on existing builds but would default to downloading *all available bundles* instead of only a subset for anyone who uses it (maybe we should be using it?).

three placetypes are added which are not present in `bundleList.js`: `campus`, `microhood` & `planet`.