### PR TITLE
result mask feature

### DIFF
--- a/lib/Result.js
+++ b/lib/Result.js
@@ -25,7 +25,7 @@ function _debugRows( rows ){
 function Result( group, done ){
   this.group = Array.isArray( group ) ? group : [];
   this.ids = {};
-  this.mask = [];
+  this.mask = new Array( this.group.length ).fill( false );
   this.pos = {
     subject: this.group.length -2,
     object: this.group.length -1
@@ -64,7 +64,12 @@ Result.subjectIdsFromRows = function( rows, filter ){
   }, {});
 };
 
-// @todo fix the mask property
+// convenience function to set mask values
+Result.prototype.setMask = function( entity, bool ){
+  if( this.pos.hasOwnProperty(entity) && -1 < this.pos[entity] ){
+    this.mask[ this.pos[entity] ] = !!bool;
+  }
+};
 
 // intersect the currect resultset with new matching rows from
 // the database.
@@ -75,7 +80,6 @@ Result.prototype.intersect = function( err, rows ){
 
   // no results were found
   if( err || !rows || !rows.length ){
-    // this.mask.unshift( 0 );
 
     // decrement iterator
     this.pos.subject--;
@@ -85,9 +89,10 @@ Result.prototype.intersect = function( err, rows ){
   // first time we have found matching rows for the query
   if( !Object.keys( this.ids ).length ){
     this.ids = Result.subjectIdsFromRows( rows );
+    this.setMask('object', true);
+    this.setMask('subject', true);
     this.pos.object = this.pos.subject;
     this.pos.subject = this.pos.object-1;
-    // this.mask.unshift( subjectIds.length );
     return;
   }
 
@@ -103,9 +108,9 @@ Result.prototype.intersect = function( err, rows ){
   // we found at least one valid child
   if( !!Object.keys( children ).length ){
     this.ids = children;
+    this.setMask('subject', true);
     this.pos.object = this.pos.subject;
     this.pos.subject = this.pos.object-1;
-    // this.mask.unshift( children.length );
     return;
   }
 
@@ -113,7 +118,6 @@ Result.prototype.intersect = function( err, rows ){
   if( DEBUG ){ console.error( 'failed!' ); }
 
   // decrement iterator
-  // this.mask.unshift( 0 );
   this.pos.subject--;
 };
 

--- a/prototype/query.js
+++ b/prototype/query.js
@@ -36,8 +36,8 @@ function reduce( index, res ){
       if( !idsArray.length ){
         const lastToken = res.group[ res.group.length -1 ];
         return index.matchSubjectDistinctSubjectIds( lastToken, ( err, rows ) => {
-          const subjectIds = rows.map( row => { return row.subjectId; } );
-          return res.done( null, subjectIds, [], res.group );
+          res.intersect( err, rows );
+          return res.done( null, res.getIdsAsArray(), [], res.group );
         });
       }
 

--- a/test/lib/Result.js
+++ b/test/lib/Result.js
@@ -8,6 +8,7 @@ module.exports.constructor = function(test, common) {
     t.equal( typeof res.getObject, 'function' );
     t.equal( typeof res.getPreviousObject, 'function' );
     t.equal( typeof res.getIdsAsArray, 'function' );
+    t.equal( typeof res.setMask, 'function' );
     t.equal( typeof res.intersect, 'function' );
 
     t.deepEqual( res.group, [] );
@@ -23,6 +24,7 @@ module.exports.constructor = function(test, common) {
   test('constructor - set group', function(t) {
     const res = new Result(['a','b','c']);
     t.deepEqual( res.group, ['a','b','c'] );
+    t.deepEqual( res.mask, [false, false, false] );
     t.end();
   });
 
@@ -103,6 +105,73 @@ module.exports.getIdsAsArray = function(test, common) {
     res2.ids = { '200': true, '201': true, '202': true };
     t.deepEqual(res2.getIdsAsArray(), [200, 201, 202]);
 
+    t.end();
+  });
+};
+
+module.exports.setMask = function(test, common) {
+  test('default mask', function(t) {
+    const res = new Result(['a','b','c']);
+    t.deepEqual(res.mask, [false, false, false]);
+    t.end();
+  });
+  test('setMask - invalid property', function(t) {
+    const res = new Result(['a','b','c']);
+    t.deepEqual(res.mask, [false, false, false]);
+    res.setMask('invalidproperty', true);
+    t.deepEqual(res.mask, [false, false, false]);
+    t.end();
+  });
+  test('setMask - subject - true', function(t) {
+    const res = new Result(['a','b','c']);
+    res.setMask('subject', true);
+    t.deepEqual(res.mask, [false, true, false]);
+    t.end();
+  });
+  test('setMask - subject - truthy', function(t) {
+    const res = new Result(['a','b','c']);
+    res.setMask('subject', 'non null string');
+    t.deepEqual(res.mask, [false, true, false]);
+    t.end();
+  });
+  test('setMask - subject - false', function(t) {
+    const res = new Result(['a','b','c']);
+    res.mask = [true, true, true];
+    res.setMask('subject', false);
+    t.deepEqual(res.mask, [true, false, true]);
+    t.end();
+  });
+  test('setMask - subject - falsy', function(t) {
+    const res = new Result(['a','b','c']);
+    res.mask = [true, true, true];
+    res.setMask('subject', null);
+    t.deepEqual(res.mask, [true, false, true]);
+    t.end();
+  });
+  test('setMask - object - true', function(t) {
+    const res = new Result(['a','b','c']);
+    res.setMask('object', true);
+    t.deepEqual(res.mask, [false, false, true]);
+    t.end();
+  });
+  test('setMask - object - truthy', function(t) {
+    const res = new Result(['a','b','c']);
+    res.setMask('object', 'non null string');
+    t.deepEqual(res.mask, [false, false, true]);
+    t.end();
+  });
+  test('setMask - object - false', function(t) {
+    const res = new Result(['a','b','c']);
+    res.mask = [true, true, true];
+    res.setMask('object', false);
+    t.deepEqual(res.mask, [true, true, false]);
+    t.end();
+  });
+  test('setMask - object - falsy', function(t) {
+    const res = new Result(['a','b','c']);
+    res.mask = [true, true, true];
+    res.setMask('object', null);
+    t.deepEqual(res.mask, [true, true, false]);
     t.end();
   });
 };

--- a/test/prototype/query.js
+++ b/test/prototype/query.js
@@ -93,7 +93,7 @@ module.exports._queryGroup = function(test, common) {
     const done = ( _err, _ids, _mask, _group ) => {
       t.deepEqual(_err, null);
       t.deepEqual(_ids, [ 100, 200, 300 ]);
-      t.deepEqual(_mask, []);
+      t.deepEqual(_mask, [ true, true, false ]);
       t.equal(_group, group);
     };
 
@@ -130,7 +130,7 @@ module.exports._queryGroup = function(test, common) {
     const done = ( _err, _ids, _mask, _group ) => {
       t.deepEqual(_err, null);
       t.deepEqual(_ids, [ 100 ]);
-      t.deepEqual(_mask, []);
+      t.deepEqual(_mask, [ true, true, true ]);
       t.equal(_group, group);
     };
 


### PR DESCRIPTION
this PR completes work on the result mask feature.

the idea here is that, for each result, we now return a mask which records which token groups were successfully used during the matching.

eg:
```
[ 'kreuzberg', 'italy', 'berlin', 'rome', 'germany' ]
[ true, false, true, false, true ]
```

the mask shows that the tokens `kreuzberg` `berlin` and `germany` were used in the match but the tokens `italy` and `rome` were not.

note: this is still a private "internal" API, there is still an additional piece of work to be done before it is exposed to the end user.

...the mask only does bookkeeping on tokens which exist in the database, if you enter an unknown token such as `foobar` then it will not be included in this mask.

eg:  the token `90210` is not present in the database
```
beverly hills 90210 ca usa

[ 'beverly hills', 'ca', 'usa' ]
[ true, true, true ]
```