### PR TITLE
revert adding placetype column

### DIFF
--- a/lib/TokenIndex.js
+++ b/lib/TokenIndex.js
@@ -18,8 +18,8 @@ TokenIndex.prototype.reset = function(){
   this.db.exec('CREATE INDEX IF NOT EXISTS lineage_cover_idx ON lineage(id, pid);');
 
   this.db.exec('DROP TABLE IF EXISTS tokens;');
-  this.db.exec('CREATE TABLE tokens( id INTEGER, layer STRING, lang STRING, tag STRING, token STRING );');
-  this.db.exec('CREATE INDEX IF NOT EXISTS tokens_cover_idx ON tokens(id, layer, lang, tag);');
+  this.db.exec('CREATE TABLE tokens( id INTEGER, lang STRING, tag STRING, token STRING );');
+  this.db.exec('CREATE INDEX IF NOT EXISTS tokens_cover_idx ON tokens(id, lang, tag);');
   this.db.exec('CREATE INDEX IF NOT EXISTS tokens_token_idx ON tokens(token);');
 
   // FTS table options
@@ -41,10 +41,9 @@ TokenIndex.prototype.checkSchema = function(){
   ]);
   Database.assertSchema(this.db, 'tokens', [
     { cid: 0, name: 'id', type: 'INTEGER', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 1, name: 'layer', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 2, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 3, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 4, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
+    { cid: 1, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 2, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 3, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
   ]);
   Database.assertSchema(this.db, 'fulltext', [
     { cid: 0, name: 'token', type: '', notnull: 0, dflt_value: null, pk: 0 }
@@ -77,13 +76,12 @@ TokenIndex.prototype.setTokens = function( id, tokens, cb ){
 
   // create prepared statement
   var stmt = this.prepare(
-    'INSERT INTO tokens ( id, layer, lang, tag, token ) VALUES ( $id, $layer, $lang, $tag, $token )'
+    'INSERT INTO tokens ( id, lang, tag, token ) VALUES ( $id, $lang, $tag, $token )'
   );
 
   try {
     tokens.forEach( token => stmt.run({
       id: id,
-      layer: token.layer,
       lang: token.lang,
       tag: token.tag,
       token: token.body

--- a/test/lib/TokenIndex.js
+++ b/test/lib/TokenIndex.js
@@ -30,10 +30,9 @@ module.exports.reset = function(test, common) {
     sql = 'PRAGMA table_info(tokens)';
     t.deepEqual( db.prepare(sql).all(), [
       { cid: 0, name: 'id', type: 'INTEGER', notnull: 0, dflt_value: null, pk: 0 },
-      { cid: 1, name: 'layer', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-      { cid: 2, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-      { cid: 3, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
-      { cid: 4, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
+      { cid: 1, name: 'lang', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+      { cid: 2, name: 'tag', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 },
+      { cid: 3, name: 'token', type: 'STRING', notnull: 0, dflt_value: null, pk: 0 }
     ]);
 
     // ensure table has been created
@@ -176,8 +175,8 @@ module.exports.setTokens = function(test, common) {
       // ensure rows have been created
       const sql = 'SELECT * FROM tokens';
       t.deepEqual( db.prepare(sql).all(), [
-        { id: 100, layer: null, lang: 'en', tag: 'abbr', token: 'test1' },
-        { id: 100, layer: null, lang: 'fr', tag: 'variant', token: 'test2' }
+        { id: 100, lang: 'en', tag: 'abbr', token: 'test1' },
+        { id: 100, lang: 'fr', tag: 'variant', token: 'test2' }
       ]);
 
     });


### PR DESCRIPTION
yesterday I merged https://github.com/pelias/placeholder/pull/73 and today I decided that was possibly not a great idea. this PR reverts part of PR73.

I'm reverting the schema changes due to unnecessary duplication of data which is better normalized:
- the placetype should not be stored in the token table, it should belong in the docs table instead.
- each token row has a wofid column which can be joined to the docs table when this string is required.
- having an additional string column per row in the token table increases the disk requirement.
- schema changes require every consumer to update their data files to remain compatible.

If we get this merged today it will hopefully prevent anyone from being forced to upgrade due to the schema incompatibility.