### PR TITLE
only deduplicate tokens within the same language

### DIFF
--- a/prototype/query.js
+++ b/prototype/query.js
@@ -3,7 +3,6 @@ var async = require('async');
 var util = require('util');
 var Result = require('../lib/Result');
 var sorted = require('../lib/sorted');
-
 var debug = false;
 
 function reduce( index, res ){

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -5,6 +5,10 @@ const _ = require('lodash'),
     analysis = require('../lib/analysis'),
     language = dir('../config/language');
 
+// list of languages / tags we favour in cases of deduplication
+const LANG_PREFS = ['eng','und'];
+const TAG_PREFS = ['preferred','abbr','label','variant','colloquial'];
+
 // insert a wof record in to index
 function insertWofRecord( wof, next ){
 
@@ -52,36 +56,36 @@ function insertWofRecord( wof, next ){
   if( 'empire' !== doc.placetype ){
 
     // add 'wof:label'
-    tokens.push({ lang: 'und', layer: doc.placetype, tag: 'label', body: wof['wof:label'] });
+    tokens.push({ lang: 'und', tag: 'label', body: wof['wof:label'] });
 
     // add 'wof:name'
-    tokens.push({ lang: 'und', layer: doc.placetype, tag: 'label', body: wof['wof:name'] });
+    tokens.push({ lang: 'und', tag: 'label', body: wof['wof:name'] });
 
     // add 'wof:abbreviation'
-    tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['wof:abbreviation'] });
+    tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:abbreviation'] });
 
     // add 'ne:abbrev'
-    // tokens.push({ lang: 'und', layer: doc.placetype, body: wof['ne:abbrev'] });
+    // tokens.push({ lang: 'und', body: wof['ne:abbrev'] });
 
     // fields specific to countries & dependencies
     if( 'country' === doc.placetype || 'dependency' === doc.placetype ) {
       if( wof['iso:country'] && wof['iso:country'] !== 'XX' ){
 
         // add 'ne:iso_a2'
-        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['ne:iso_a2'] });
+        tokens.push({ lang: 'und', tag: 'abbr', body: wof['ne:iso_a2'] });
 
         // add 'ne:iso_a3'
-        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['ne:iso_a3'] });
+        tokens.push({ lang: 'und', tag: 'abbr', body: wof['ne:iso_a3'] });
 
         // add 'wof:country'
         // warning: eg. FR for 'French Guiana'
-        // tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['wof:country'] });
+        // tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:country'] });
 
         // add 'iso:country'
-        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['iso:country'] });
+        tokens.push({ lang: 'und', tag: 'abbr', body: wof['iso:country'] });
 
         // add 'wof:country_alpha3'
-        tokens.push({ lang: 'und', layer: doc.placetype, tag: 'abbr', body: wof['wof:country_alpha3'] });
+        tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:country_alpha3'] });
       }
     }
 
@@ -98,7 +102,6 @@ function insertWofRecord( wof, next ){
         // index each alternative name
         for( var n in wof[ attr ] ){
           tokens.push({
-            layer: doc.placetype,
             lang: match[1],
             tag: match[2],
             body: wof[ attr ][ n ]
@@ -146,14 +149,40 @@ function insertWofRecord( wof, next ){
   // normalize tokens
   tokens = tokens.reduce(( res, token ) => {
     analysis.normalize( token.body ).forEach( norm => {
-      res.push({ lang: token.lang, layer: token.layer, tag: token.tag, body: norm });
+      res.push({ lang: token.lang, tag: token.tag, body: norm });
     });
     return res;
   }, []);
 
+  // sort tokens (for optimal deduplication)
+  tokens.sort((i1, i2) => {
+
+    // sort by language
+    const l1 = LANG_PREFS.indexOf(i1.lang);
+    const l2 = LANG_PREFS.indexOf(i2.lang);
+
+    if (l1 === -1){ return +1; }
+    if (l2 === -1){ return -1; }
+    if (l1 > l2){ return +1; }
+    if (l1 < l2){ return -1; }
+
+    // sort by tag
+    const t1 = TAG_PREFS.indexOf(i1.tag);
+    const t2 = TAG_PREFS.indexOf(i2.tag);
+
+    if (t1 === -1){ return +1; }
+    if (t2 === -1){ return -1; }
+    if (t1 > t2){ return +1; }
+    if (t1 < t2){ return -1; }
+
+    return 0;
+  });
+
   // deduplicate tokens
   var seen = {};
   tokens = tokens.filter( token => {
+    if( seen.hasOwnProperty( 'eng:' + token.body ) ){ return false; }
+    if( seen.hasOwnProperty( 'und:' + token.body ) ){ return false; }
     const key = token.lang + ':' + token.body;
     return seen.hasOwnProperty( key ) ? false : ( seen[ key ] = true );
   });

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -154,7 +154,8 @@ function insertWofRecord( wof, next ){
   // deduplicate tokens
   var seen = {};
   tokens = tokens.filter( token => {
-    return seen.hasOwnProperty( token.body ) ? false : ( seen[ token.body ] = true );
+    const key = token.lang + ':' + token.body;
+    return seen.hasOwnProperty( key ) ? false : ( seen[ key ] = true );
   });
 
   // deduplicate parent ids

--- a/query/match_subject_object.sql
+++ b/query/match_subject_object.sql
@@ -7,5 +7,6 @@ AND t2.token = $object
 AND t1.lang IN ( t2.lang, 'eng', 'und' )
 -- AND t1.tag NOT IN ( 'colloquial' )
 -- AND t2.tag NOT IN ( 'colloquial' )
+GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC
 LIMIT $limit

--- a/query/match_subject_object.sql
+++ b/query/match_subject_object.sql
@@ -4,7 +4,11 @@ FROM lineage AS l1
   JOIN tokens AS t2 ON t2.id = l1.pid
 WHERE t1.token = $subject
 AND t2.token = $object
-AND t1.lang IN ( t2.lang, 'eng', 'und' )
+AND (
+  t1.lang = t2.lang OR
+  t1.lang IN ( 'eng', 'und' ) OR
+  t2.lang IN ( 'eng', 'und' )
+)
 -- AND t1.tag NOT IN ( 'colloquial' )
 -- AND t2.tag NOT IN ( 'colloquial' )
 GROUP BY t1.id, t2.id

--- a/query/match_subject_object_autocomplete.sql
+++ b/query/match_subject_object_autocomplete.sql
@@ -7,5 +7,6 @@ AND t2.token LIKE $object
 AND t1.lang IN ( t2.lang, 'eng', 'und' )
 -- AND t1.tag NOT IN ( 'colloquial' )
 -- AND t2.tag NOT IN ( 'colloquial' )
+GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC
 LIMIT $limit

--- a/query/match_subject_object_autocomplete.sql
+++ b/query/match_subject_object_autocomplete.sql
@@ -4,7 +4,11 @@ FROM lineage AS l1
   JOIN tokens AS t2 ON t2.id = l1.pid
 WHERE t1.token = $subject
 AND t2.token LIKE $object
-AND t1.lang IN ( t2.lang, 'eng', 'und' )
+AND (
+  t1.lang = t2.lang OR
+  t1.lang IN ( 'eng', 'und' ) OR
+  t2.lang IN ( 'eng', 'und' )
+)
 -- AND t1.tag NOT IN ( 'colloquial' )
 -- AND t2.tag NOT IN ( 'colloquial' )
 GROUP BY t1.id, t2.id

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -49,7 +49,7 @@
 101751659 Zagreb, Croatia
 101751703 Budapest, Hungary
 101751737 Dublin, Ireland
-85632641 Diego Garcia, British Indian Ocean Territory
+1125918569 Diego Garcia, British Indian Ocean Territory
 101751753 Reykjavik, Iceland
 1125783915 Saint Helier, Jersey
 421186515 Kingston, Jamaica

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -36,7 +36,7 @@
 101750367 London, United Kingdom
 890451719 St. George's, Grenada
 1091680781 Cayenne, French Guiana
-85632547 St Peter Port, Guernsey
+1125821075 St Peter Port, Guernsey
 421168965 Accra, Ghana
 101753853 Gibraltar, Gibraltar
 101870623 Nuuk, Greenland

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -51,7 +51,7 @@
 101751737 Dublin, Ireland
 85632641 Diego Garcia, British Indian Ocean Territory
 101751753 Reykjavik, Iceland
-85632593 Saint Helier, Jersey
+1125783915 Saint Helier, Jersey
 421186515 Kingston, Jamaica
 85672817 Tokyo, Japan
 890440079 Basseterre, Saint Kitts and Nevis

--- a/test/cases/citySearch.txt
+++ b/test/cases/citySearch.txt
@@ -1072,7 +1072,7 @@
 85849939 South Peabody
 101750613 South Shields
 102018849 South Tangerang
-85975801 South Vineland
+1125818773 South Vineland
 85850209 South Whittier
 101913905 Southampton
 101750371 Southend-on-Sea

--- a/test/functional.js
+++ b/test/functional.js
@@ -1,7 +1,7 @@
 
 var Placeholder = require('../Placeholder');
 
-module.exports.tokenize = function(test, util) {
+module.exports.functional = function(test, util) {
 
   // load data
   var ph = new Placeholder();
@@ -29,6 +29,17 @@ module.exports.tokenize = function(test, util) {
 
   // should not include county: 102081377, or localadmin: 404482867
   assert('lancaster lancaster pa', [ 101718643, 404487183, 404487185 ]);
+
+  // assertions from pelias acceptance-test suite
+  assert('灣仔, 香港', [85671779, 421187171]);
+  assert('new york city, usa', [85977539]);
+  assert('sendai, japan', [102031919, 1108739995, 1125901991]);
+  assert('Észak-Alföld', [404227483]);
+  assert('Comunidad Foral De Navarra, ES', [404227391]);
+  assert('Île-De-France, France', [404227465]);
+  assert('Dél-Dunántúl, HU', [404227491]);
+  assert('Sardegna, Italy', [404227535]);
+  assert('Közép-Magyarország, Hungary', [404227489]);
 };
 
 // convenience function for writing quick 'n easy test cases

--- a/test/functional_autocomplete.js
+++ b/test/functional_autocomplete.js
@@ -1,7 +1,7 @@
 
 var Placeholder = require('../Placeholder');
 
-module.exports.tokenize = function(test, util) {
+module.exports.functional = function(test, util) {
 
   // load data
   var ph = new Placeholder();

--- a/test/integration.js
+++ b/test/integration.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var path = require('path');
 
 var tests = [
+  './lib/Queries',
   './prototype/tokenize_integration',
   './prototype/query_integration',
   './functional',

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -871,6 +871,21 @@ module.exports.add_names = function(test, util) {
     });
   });
 
+  // deduplicate tokens within the same language
+  test( 'token deduplication', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord(params({
+      'name:eng_x_preferred': [ 'A', 'B' ],
+      'name:eng_x_variant': [ 'A', 'B' ],
+      'name:ita_x_preferred': [ 'A', 'B' ],
+      'name:ita_x_variant': [ 'A', 'B' ]
+    }), function(){
+      t.deepEqual( mock._calls.set.length, 1 );
+      t.deepEqual( mock._calls.set[0][1].names, { eng: [ 'A', 'B' ], ita: [ 'A', 'B' ] });
+      t.end();
+    });
+  });
+
 };
 
 // In the USA we would like to favor the 'wof:label' property over the 'name:eng_x_preferred' property.

--- a/test/units.js
+++ b/test/units.js
@@ -9,7 +9,6 @@ var tests = [
   './lib/Database',
   './lib/DocStore',
   './lib/TokenIndex',
-  './lib/Queries',
   './lib/Result',
   './prototype/wof',
   './prototype/io',


### PR DESCRIPTION
this PR changes the token deduplication functionality.

prior to this PR, we would deduplicate any two tokens which were the exact same, which reduced the size of the database (by a fair bit actually!).

this PR changes that behavior to only deduplicate tokens *within the same language*, the net effect is that the same token can be stored multiple times *in different languages*, but only once *per language*.

the motivation behind this is to allow for a better 'language crosswalk', we do not allow queries to be specified in many different languages, only the language of the right-most token, `English` and `Undefined`.

deduplicating the tokens meant that only the first language for each token was selected, causing queries in another language to fail.

Eg. the term 'New York City' appears in many languages but if the first version was Italian then it would only match in queries where the rest of the tokens were also in Italian.

I also added a `GROUP BY` condition for performance reasons and to avoid reaching the `$LIMIT` for queries.

note: this increases the database size by ~30% `946M Nov 21 17:57 store.sqlite3`