### PR TITLE
Update TravisCI S3 Bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   fast_finish: true
 script: npm run travis
 env:
-  - BUCKET=http://pelias-data.s3.amazonaws.com/placeholder
+  - BUCKET=http://geocodeearth-pelias-data.s3.amazonaws.com/placeholder
 before_install:
   - npm i -g npm@^3.0.0
 before_script:


### PR DESCRIPTION
[geocode.earth](http://geocode.earth/) is now hosting the data publicly, since the Mapzen S3 bucket shut down.

This should allow the tests on Travis to pass again.

Connects https://github.com/pelias/pelias/issues/703