### PR TITLE
Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ FROM pelias/baseimage
 # note: this is done in one command in order to keep down the size of intermediate containers
 RUN apt-get update && apt-get install -y build-essential python jq && rm -rf /var/lib/apt/lists/*
 
-# clone repo
-RUN git clone https://github.com/pelias/placeholder.git /code/pelias/placeholder
-
 # change working dir
 ENV WORKDIR /code/pelias/placeholder
 WORKDIR ${WORKDIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,14 @@ RUN git clone https://github.com/pelias/placeholder.git /code/pelias/placeholder
 ENV WORKDIR /code/pelias/placeholder
 WORKDIR ${WORKDIR}
 
+# copy package.json first to prevent npm install being rerun when only code changes
+COPY ./package.json ${WORK}
+RUN npm install
+
 # copy code from local checkout
 ADD . ${WORKDIR}
 
 ENV WOF_DIR '/data/whosonfirst/data'
 ENV PLACEHOLDER_DATA '/data/placeholder'
-
-# install npm dependencies
-RUN npm install
 
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,4 @@ ENV PLACEHOLDER_DATA '/data/placeholder'
 # install npm dependencies
 RUN npm install
 
-RUN export extract_file=${PLACEHOLDER_DATA}/wof.extract
-
 CMD [ "npm", "start" ]


### PR DESCRIPTION
While working on some automated builds I noticed some possible improvements to the Dockerfile.

Firstly it looks like we left an old `git clone` in there, when the intent is to copy the code from a local checkout. It looks like the code was being cloned from github, and then overwritten with local code. I'm sure there are a bunch of ways this can cause issues with conflicting code versions, and hopefully we didn't run into any problems. Yikes!

Second, this Dockerfile ran `npm install` near the end, and didn't use any tricks to help speed up repeated builds by skipping `npm install` when no dependencies have changed.