### PR TITLE
match 'nearby' places, rudimentary support for RTL languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The data is sourced from the [whosonfirst](https://github.com/whosonfirst-data/w
 
 Placeholder supports searching on and retrieving tokens in different languages and also offers support for synonyms and abbreviations.
 
+The engine includes a rudimentary language detection algorithm which attempts to detect right-to-left languages and languages which write their addresses in major-to-minor format. It will then reverse the tokens to re-order them in to minor-to-major ordering.
+
 ---
 
 ## nodejs version
@@ -154,6 +156,22 @@ the `/parser/search` endpoint accepts a `?mode=live` parameter pair which can be
 in this mode the final token of each input text is considered as 'incomplete', meaning that the user has potentially only typed part of a token.
 
 this mode is currently in BETA, the interface and behaviour may change over time.
+
+### configuring the rtree threshold
+
+the default matching strategy uses the `lineage` table to ensure that token pairs represent a valid child->parent relationship. this ensures that queries like 'London France' do not match, because there is no entry in the lineage table linking those two places together.
+
+in some cases it's preferable to fall back to a matching strategy which considers geographically nearby places with a matching name, even if that relationship does not explicitly exist in the lineage table.
+
+for example, 'Basel France' will return 'Basel Switzerland'. this is useful for handling user input errors and errors and omissions from the lineage table.
+
+in the example above, 'Basel France' only matches because the bounding box of 'Basel' overlaps the bounding box of 'France' and no other valid entry for 'Basel France' exists.
+
+the definition of what is 'nearby' is configurable, the bbox for the minor term (left token) is expanded by a threshold (the threshold is added or subtracted to each of the bbox vertices).
+
+by default the threshold is set as `0.2` (degrees), any float value between 0 and 1 may be specified via the enviornment variable `RTREE_THRESHOLD`.
+
+a setting of less than 0 will disable the rtree functionality completely. disabling the rtree will result in nearby queries such as 'Basel France' returning 'France' instead of 'Basel Switzerland'.
 
 ---
 

--- a/lib/DocStore.js
+++ b/lib/DocStore.js
@@ -9,6 +9,35 @@ util.inherits( DocStore, Database );
 DocStore.prototype.reset = function(){
   this.db.exec('DROP TABLE IF EXISTS docs');
   this.db.exec('CREATE TABLE docs( id INTEGER PRIMARY KEY, json TEXT )');
+
+  // create rtree table
+  this.db.exec('CREATE VIRTUAL TABLE IF NOT EXISTS rtree USING rtree( id, minX, maxX, minY, maxY, minZ, maxZ )');
+
+  // triggers to keep the rtree index up-to-date
+  var triggers = {
+    insert: `INSERT INTO rtree ( id, minX, maxX, minY, maxY, minZ, maxZ ) VALUES (
+      new.id,
+      json_extract( json( '[' || json_extract( new.json, '$.geom.bbox' ) || ']' ), '$[0]' ),
+      json_extract( json( '[' || json_extract( new.json, '$.geom.bbox' ) || ']' ), '$[2]' ),
+      json_extract( json( '[' || json_extract( new.json, '$.geom.bbox' ) || ']' ), '$[1]' ),
+      json_extract( json( '[' || json_extract( new.json, '$.geom.bbox' ) || ']' ), '$[3]' ),
+      json_extract( new.json, '$.rank.min' ),
+      json_extract( new.json, '$.rank.max' )
+    )`,
+    delete: 'DELETE FROM rtree WHERE id = old.id'
+  };
+
+  this.db.exec(`CREATE TRIGGER IF NOT EXISTS rtree_insert_trigger
+    AFTER INSERT ON docs
+    BEGIN ${triggers.insert}; END`);
+
+  this.db.exec(`CREATE TRIGGER IF NOT EXISTS rtree_delete_trigger
+    AFTER DELETE ON docs
+    BEGIN ${triggers.delete}; END`);
+
+  this.db.exec(`CREATE TRIGGER IF NOT EXISTS rtree_update_trigger
+    AFTER UPDATE ON docs
+    BEGIN ${triggers.delete}; ${triggers.insert}; END`);
 };
 
 // ensure that the database schema matches what is expected by the codebase
@@ -16,6 +45,15 @@ DocStore.prototype.checkSchema = function(){
   Database.assertSchema(this.db, 'docs', [
     { cid: 0, name: 'id', type: 'INTEGER', notnull: 0, dflt_value: null, pk: 1 },
     { cid: 1, name: 'json', type: 'TEXT', notnull: 0, dflt_value: null, pk: 0 }
+  ]);
+  Database.assertSchema(this.db, 'rtree', [
+    { cid: 0, name: 'id', type: '', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 1, name: 'minX', type: '', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 2, name: 'maxX', type: '', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 3, name: 'minY', type: '', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 4, name: 'maxY', type: '', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 5, name: 'minZ', type: '', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 6, name: 'maxZ', type: '', notnull: 0, dflt_value: null, pk: 0 }
   ]);
 };
 

--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -5,7 +5,10 @@ const PARTIAL_TOKEN_SUFFIX = require('./analysis').PARTIAL_TOKEN_SUFFIX;
 const REMOVE_PARTIAL_TOKEN_REGEX = new RegExp(PARTIAL_TOKEN_SUFFIX, 'g');
 const MAX_RESULTS = 100;
 const DEBUG = false;
-const AUTOCOMPLETE = false;
+
+// set threshold bounds between 0.0-1.0 (degrees), defaults to 0.2
+const RTREE_ENV = parseFloat( process.env.RTREE_THRESHOLD );
+const RTREE_THRESHOLD = !isNaN( RTREE_ENV ) ? Math.max( 0, Math.min( 1, RTREE_ENV ) ) : 0.2;
 
 function debug( stmt, args, cb ){
   if( !DEBUG ){ return cb; }
@@ -127,6 +130,44 @@ module.exports.matchSubjectObject = function( subject, object, cb ){
       {
         subject: subject,
         object: object,
+        limit: MAX_RESULTS
+      },
+      cb
+    );
+  }
+};
+
+module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb ){
+  var isPartialToken = object.slice(-1) === PARTIAL_TOKEN_SUFFIX;
+
+  // no-op for empty string
+  if( '' === subject.trim() ){ return cb( null, [] ); }
+  if( '' === object.trim() ){ return cb( null, [] ); }
+
+  // no-op when theshold is less than 0
+  if( 0 > RTREE_THRESHOLD ){ return cb( null, [] ); }
+
+  if( isPartialToken ){
+    object = object.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '');
+    if( '' === object.trim() ){ return cb( null, [] ); }
+
+    this._queryAll(
+      this.prepare( query.match_subject_object_geom_intersects_autocomplete ),
+      {
+        subject: subject,
+        object: `"${object}" OR "${object}"*`,
+        threshold: RTREE_THRESHOLD,
+        limit: MAX_RESULTS
+      },
+      cb
+    );
+  } else {
+    this._queryAll(
+      this.prepare( query.match_subject_object_geom_intersects ),
+      {
+        subject: subject,
+        object: object,
+        threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },
       cb

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -113,8 +113,17 @@ function normalize( input ){
   });
 }
 
+// try to detect languages which write their addresses in the opposite order-of-presentation to how it's
+// done in the west.
+// http://www.columbia.edu/~fdc/postal/#general
+const REGEX_MAJOR_TO_MINOR = /[\u0591-\u07FF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF\u0400-\u04FF]/;
+
 function tokenize( input ){
   return normalize(input).map( function( synonym ){
+    // reverse tokens for major-to-minor address schemes
+    if( REGEX_MAJOR_TO_MINOR.test( synonym ) ){
+      return synonym.split(/\s+/g).reverse();
+    }
     return synonym.split(/\s+/g);
   });
 }
@@ -122,3 +131,4 @@ function tokenize( input ){
 module.exports.normalize = normalize;
 module.exports.tokenize = tokenize;
 module.exports.PARTIAL_TOKEN_SUFFIX = PARTIAL_TOKEN_SUFFIX;
+module.exports.REGEX_MAJOR_TO_MINOR = REGEX_MAJOR_TO_MINOR;

--- a/prototype/query.js
+++ b/prototype/query.js
@@ -60,8 +60,20 @@ function reduce( index, res ){
   // regular query
   else {
     index.matchSubjectObject( res.getSubject(), res.getObject(), (err, rows) => {
-      res.intersect( err, rows );
-      reduce( index, res );
+
+      // perform a query for nearby features and include them in the results
+      if( !rows || rows.length === 0 ){
+        index.matchSubjectObjectGeomIntersects( res.getSubject(), res.getObject(), (err2, rows2) => {
+          res.intersect( err2, rows2 );
+          reduce( index, res );
+        });
+      }
+
+      // do not perform a nearby search
+      else {
+        res.intersect( err, rows );
+        reduce( index, res );
+      }
     });
   }
 }

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -25,6 +25,7 @@ function insertWofRecord( wof, next ){
     name: wof['wof:label'] || wof['wof:name'],
     abbr: getAbbreviation( wof ),
     placetype: wof['wof:placetype'],
+    rank: getRank( wof['wof:placetype'] ),
     population: getPopulation( wof ),
     popularity: wof['qs:photo_sum'],
     lineage: wof['wof:hierarchy'],
@@ -281,6 +282,21 @@ function getAbbreviation( wof ) {
   } else if( wof['wof:abbreviation'] ) {
     return wof['wof:abbreviation'];
   }
+}
+
+const PLACETYPE_RANK = [
+  'venue', 'address', 'building', 'campus', 'microhood', 'neighbourhood', 'macrohood', 'borough', 'postalcode',
+  'locality', 'metro area', 'localadmin', 'county', 'macrocounty', 'region', 'macroregion', 'marinearea',
+  'disputed', 'dependency', 'country', 'empire', 'continent', 'ocean', 'planet'
+];
+
+// this function returns an integer representation of the placetype,
+function getRank( placetype ){
+  var rank = PLACETYPE_RANK.indexOf((placetype || '').toLowerCase().trim());
+  return {
+    min: rank,
+    max: rank +1
+  };
 }
 
 module.exports.insertWofRecord = insertWofRecord;

--- a/query/build_rtree.sql
+++ b/query/build_rtree.sql
@@ -1,0 +1,23 @@
+
+-- create virtual table
+CREATE VIRTUAL TABLE IF NOT EXISTS rtree USING rtree(
+   id,              -- Integer primary key
+   minX, maxX,      -- Minimum and maximum X coordinate
+   minY, maxY,      -- Minimum and maximum Y coordinate
+   minZ, maxZ       -- Minimum and maximum 'rank'
+);
+
+-- delete existing values
+DELETE FROM rtree;
+
+-- fill rtree
+INSERT INTO rtree
+SELECT
+  id,
+  json_extract( json( '[' || json_extract( json, '$.geom.bbox' ) || ']' ), '$[0]' ) AS minX,
+  json_extract( json( '[' || json_extract( json, '$.geom.bbox' ) || ']' ), '$[2]' ) AS maxX,
+  json_extract( json( '[' || json_extract( json, '$.geom.bbox' ) || ']' ), '$[1]' ) AS minY,
+  json_extract( json( '[' || json_extract( json, '$.geom.bbox' ) || ']' ), '$[3]' ) AS maxY,
+  json_extract( json, '$.rank.min' ) AS minZ,
+  json_extract( json, '$.rank.max' ) AS maxZ
+FROM docs;

--- a/query/match_subject_object_geom_intersects.sql
+++ b/query/match_subject_object_geom_intersects.sql
@@ -1,0 +1,24 @@
+SELECT t1.id AS subjectId, t2.id as objectId
+FROM rtree AS r1, rtree AS r2
+  JOIN tokens AS t1 ON t1.id = r1.id
+  JOIN tokens AS t2 ON t2.id = r2.id
+WHERE t1.token = $subject
+AND t2.token = $object
+AND (
+  t1.lang = t2.lang OR
+  t1.lang IN ( 'eng', 'und' ) OR
+  t2.lang IN ( 'eng', 'und' )
+)
+-- https://silentmatt.com/rectangle-intersection/
+AND (
+  r1.maxZ < r2.minZ AND
+  r1.minX - $threshold < r2.maxX AND
+  r1.maxX + $threshold > r2.minX AND
+  r1.minY - $threshold < r2.maxY AND
+  r1.maxY + $threshold > r2.minY
+)
+-- AND t1.tag NOT IN ( 'colloquial' )
+-- AND t2.tag NOT IN ( 'colloquial' )
+GROUP BY t1.id, t2.id
+ORDER BY t1.id ASC, t2.id ASC
+LIMIT $limit

--- a/query/match_subject_object_geom_intersects_autocomplete.sql
+++ b/query/match_subject_object_geom_intersects_autocomplete.sql
@@ -1,0 +1,25 @@
+SELECT t1.id AS subjectId, t2.id as objectId
+FROM rtree AS r1, rtree AS r2
+  JOIN tokens AS t1 ON t1.id = r1.id
+  JOIN tokens AS t2 ON t2.id = r2.id
+    JOIN fulltext AS f2 ON f2.rowid = t2.rowid
+WHERE t1.token = $subject
+AND f2.fulltext MATCH $object
+AND (
+  t1.lang = t2.lang OR
+  t1.lang IN ( 'eng', 'und' ) OR
+  t2.lang IN ( 'eng', 'und' )
+)
+-- https://silentmatt.com/rectangle-intersection/
+AND (
+  r1.maxZ < r2.minZ AND
+  r1.minX - $threshold < r2.maxX AND
+  r1.maxX + $threshold > r2.minX AND
+  r1.minY - $threshold < r2.maxY AND
+  r1.maxY + $threshold > r2.minY
+)
+-- AND t1.tag NOT IN ( 'colloquial' )
+-- AND t2.tag NOT IN ( 'colloquial' )
+GROUP BY t1.id, t2.id
+ORDER BY t1.id ASC, t2.id ASC
+LIMIT $limit

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -110,6 +110,9 @@ function mapResult( ph, result, parents, lang ){
   // delete language properties
   delete result.names;
 
+  // delete rank properties
+  delete result.rank;
+
   result.lineage = result.lineage.map( function( lineage ){
     return mapLineage( ph, lineage, parents, lang );
   });

--- a/test/cases/citySearch.txt
+++ b/test/cases/citySearch.txt
@@ -531,7 +531,8 @@
 102017581 Iquique
 85979035 Irondequoit
 85923131 Irvine, CA
-404227469 Irvine, England
+101872479 Irvine, Scotland
+101872479 Irvine, England
 101725697 Irving
 85827089 Irvington
 1158857275 Islington

--- a/test/functional.js
+++ b/test/functional.js
@@ -15,8 +15,8 @@ module.exports.functional = function(test, util) {
   assert('ケープタウン 南アフリカ', [101928027]);
   assert('경기도 광명시', [890472589]);
   assert('서울 마포구', [890473201]);
-  assert('부산광역시 부산진구', [102026581]);
-  assert('전라북도 전주시 완산구', [890476473]);
+  assert('부산광역시 부산진구', [890475779]);
+  assert('전라북도 전주시 완산구', [102026471]);
 
   assert('london on', [ 101735809 ]);
   assert('paris, tx', [ 101725293 ]);

--- a/test/lib/analysis.js
+++ b/test/lib/analysis.js
@@ -112,6 +112,28 @@ module.exports.tokenize = function(test, common) {
   assert( 'Sendai-shi', [[ 'sendaishi' ], [ 'sendai', 'shi' ]] );
 };
 
+module.exports.minor_to_major = function(test, common) {
+
+  var isMajorToMinor = function( str ){
+    return analysis.REGEX_MAJOR_TO_MINOR.test( str );
+  };
+
+  test( 'minor-to-major', function(t) {
+    t.false( isMajorToMinor('London, UK'), 'English' );
+    t.false( isMajorToMinor('Köln Deutschland'), 'German' );
+    t.false( isMajorToMinor('Orléans Nîmes Besançon'), 'French' );
+    t.end();
+  });
+
+  test( 'major-to-minor', function(t) {
+    t.true( isMajorToMinor('г.Москва'), 'Russian' );
+    t.true( isMajorToMinor('경기도 광명시'), 'Korean' );
+    t.true( isMajorToMinor('ישראל'), 'Hebrew' );
+    t.true( isMajorToMinor('دبي'), 'Arabic' );
+    t.end();
+  });
+};
+
 // convenience function for writing quick 'n easy test cases
 function runner( test, method, actual, expected ){
   test( actual, function(t) {

--- a/test/prototype/query.js
+++ b/test/prototype/query.js
@@ -77,20 +77,24 @@ module.exports._queryGroup = function(test, common) {
   test('_queryGroup - multiple tokens - no matches', function(t) {
 
     const group = ['hello world', 'test', 'foo bar'];
-    t.plan(8);
+    t.plan(10);
 
     const index = {
       matchSubjectObject: ( subject, object, cb ) => {
         t.ok(true);
-        return cb( null, new Result() );
+        return cb( null, [] );
       },
-      matchSubjectDistinctSubjectIds: ( phrase, cb ) => {
-        t.equal(phrase, 'foo bar');
+      matchSubjectDistinctSubjectIds: ( subject, cb ) => {
+        t.equal(subject, 'foo bar');
         return cb( null, [
           { subjectId: 100 },
           { subjectId: 200 },
           { subjectId: 300 },
         ]);
+      },
+      matchSubjectObjectGeomIntersects: ( subject, object, cb ) => {
+        t.ok(true);
+        return cb( null, [] );
       }
     };
 
@@ -129,6 +133,10 @@ module.exports._queryGroup = function(test, common) {
               { subjectId: 900, objectId: 990 },
             ]);
         }
+      },
+      matchSubjectObjectGeomIntersects: ( subject, object, cb ) => {
+        t.ok(true);
+        return cb( null, [] );
       }
     };
 

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -79,6 +79,7 @@ module.exports.store_record = function(test, util) {
           name: undefined,
           names: {},
           placetype: undefined,
+          rank: { min: -1, max: 0 },
           population: undefined,
           popularity: undefined,
           abbr: undefined,


### PR DESCRIPTION
This PR adds two major features to improve token matching:

1. Adds an rtree table which can be used to match nearby places with the target name, despite not being explicitely listed in the heirarchy.
2. Detects right-to-left languages and languages which write their addresses in major-to-minor format, then reversing the token order.

The rtree table is 3 dimensional, containing both the x, y bounds of each place but also a 'rank' of each place which can be used when comparing two places, to ensure that the right token represents a 'more major' place than the token on the left.

The database is 100% backwards compatible, so I have published the data ahead of the code being released.