### PR TITLE
Streamline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,58 @@
 [![Build Status](https://travis-ci.org/pelias/placeholder.png?branch=master)](https://travis-ci.org/pelias/placeholder)
 [![Greenkeeper badge](https://badges.greenkeeper.io/pelias/placeholder.svg)](https://greenkeeper.io/)
 
-## natural language parser for geographic text
+Placeholder is a parser for text inputs that understands relationships. It
+knows, for example, that Paris is a `city` in a `country` called France.
+
+This allows for Placeholder to assist Pelias in parsing queries that might be
+ambiguous without that understanding. Placeholder can also serve as a fully
+functional coarse geocoder in its own right.
+
+## Requirements
+
+Node.j 6 or newer
+SQLite 3.11 or newer
+
+## Installation
+
+```bash
+$ git clone git@github.com:pelias/placeholder.git && cd placeholder
+$ npm install
+```
+
+### Download the required database files
+
+Placeholder uses an SQLite database with pre-processed data. This database is about 500MB and is frequently rebuilt and served publicly for convenience.
+```bash
+$ mkdir data
+$ curl -s https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz | gunzip > data/store.sqlite3;
+```
+
+### Run Placeholder Service
+
+```bash
+$ PORT=6100 npm start;
+```
+
+### Open browser
+
+The server should now be running and you should be able to access the http API:
+
+```bash
+http://localhost:6100/
+```
+
+Try the following paths:
+
+```javascript
+/demo
+/parser/search?text=london
+/parser/findbyid?ids=101748479
+/parser/query?text=london
+/parser/tokenize?text=sydney new south wales
+```
+
+## How Placeholder works
 
 This engine takes unstructured input text, such as 'Neutral Bay North Sydney New South Wales' and attempts to deduce the geographic area the user is referring to.
 
@@ -30,100 +81,31 @@ The engine includes a rudimentary language detection algorithm which attempts to
 
 ---
 
-## nodejs version
+## Additional Features
 
-nodejs `v6.11.4` or greater is required, running the library on an older version of node will result in an error:
+### Changing Languages
 
-```bash
-bash-3.2$ node --version
-v4.9.1
+The `/parser/search` endpoint accepts a `?lang=xxx` property which can be used to vary the language of data returned.
 
-bash-3.2$ node -e 'require("better-sqlite3")'
-FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal.
-Abort trap: 6
+For example, the following urls will return strings in Japanese / Russian where available:
+
 ```
-
-## install
-
-```bash
-$ git clone git@github.com:pelias/placeholder.git && cd placeholder
-$ npm install
-```
-
-### download the required database files
-
-```bash
-$ mkdir data
-$ curl -s https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz | gunzip > data/store.sqlite3;
-```
-
-### confirm the build was successful
-
-```bash
-$ npm test
-```
-
-```bash
-$ npm run cli -- san fran
-
-> pelias-placeholder@1.0.0 cli
-> node cmd/cli.js "san" "fran"
-
-san fran
-
-took: 3ms
- - 85922583	locality 	San Francisco
-```
-
----
-
-## run server
-
-```bash
-$ PORT=6100 npm start;
-```
-
-### open browser
-
-the server should now be running and you should be able to access the http API:
-
-```bash
-http://localhost:6100/
-```
-
-try the following paths:
-
-```javascript
-/demo
-/parser/search?text=london
-/parser/findbyid?ids=101748479
-/parser/query?text=london
-/parser/tokenize?text=sydney new south wales
-```
-
-### changing languages
-
-the `/parser/search` endpoint accepts a `?lang=xxx` property which can be used to vary the language of data returned.
-
-for example, the following urls will return strings in Japanese / Russian where available:
-
-```javascript
 /parser/search?text=germany&lang=jpn
 /parser/search?text=germany&lang=rus
 ```
 
-documents returned by `/parser/search` contain a boolean property named `languageDefaulted` which indicates if the service was able to find a translation in the language you request (false) or whether it returned the default language (true).
+Documents returned by `/parser/search` contain a boolean property named `languageDefaulted` which indicates if the service was able to find a translation in the language you request (false) or whether it returned the default language (true).
 
 The `/parser/findbyid` endpoint also accepts a `?lang=xxx` property which will return the selected lang if the translation exists and all translations otherwise.
 
-for example, the following url will return strings in French / Korean where available:
+For example, the following url will return strings in French / Korean where available:
 
 ```javascript
 /parser/findbyid?ids=85633147,102191581,85862899&lang=fra
 /parser/findbyid?ids=85633147,102191581,85862899&lang=kor
 ```
 
-the demo is also able to serve responses in different languages by providing the language code in the URL anchor:
+The demo is also able to serve responses in different languages by providing the language code in the URL anchor:
 
 ```bash
 /demo#jpn
@@ -133,19 +115,19 @@ the demo is also able to serve responses in different languages by providing the
 ... etc.
 ```
 
-### filtering by placetype
+### Filtering by Placetype
 
-the `/parser/search` endpoint accepts a `?placetype=xxx` parameter which can be used to control the placetype of records which are returned.
+The `/parser/search` endpoint accepts a `?placetype=xxx` parameter which can be used to control the placetype of records which are returned.
 
-the API does not provide any performance benefits, it is simply a convenience API to filter by a whitelist.
+The API does not provide any performance benefits, it is simply a convenience API to filter by a whitelist.
 
-you may specify multiple placetypes using a comma to separate them, such as `?placetype=xxx,yyy`, these are matched as OR conditions. eg: (xxx OR yyy)
+You may specify multiple placetypes using a comma to separate them, such as `?placetype=xxx,yyy`, these are matched as OR conditions. eg: (xxx OR yyy)
 
-for example:
+For example:
 
-the query `search?text=luxemburg` will return results for the `country`, `region`, `locality` etc.
+The query `search?text=luxemburg` will return results for the `country`, `region`, `locality` etc.
 
-you can use the placetype filter to control which records are returned:
+You can use the placetype filter to control which records are returned:
 
 ```
 # all matching results
@@ -158,7 +140,7 @@ search?text=luxemburg&placetype=country
 search?text=luxemburg&placetype=country,region
 ```
 
-### live mode (BETA)
+### Live Mode (BETA)
 
 the `/parser/search` endpoint accepts a `?mode=live` parameter pair which can be used to enable an autocomplete-style API.
 
@@ -184,7 +166,7 @@ a setting of less than 0 will disable the rtree functionality completely. disabl
 
 ---
 
-## run the interactive shell
+## Run the interactive shell
 
 ```bash
 $ npm run repl
@@ -225,7 +207,7 @@ placeholder > id 85772991
 
 ---
 
-## configuration for pelias API
+## Configuration for pelias API
 
 While Placeholder can be used as a stand-alone application or included with other geographic software / search engines, it is designed for the [Pelias geocoder](https://github.com/pelias/pelias).
 
@@ -233,9 +215,9 @@ To connect Placeholder service to the Pelias API, [configure the pelias config f
 
 ---
 
-## tests
+## Tests
 
-### run the test suite
+### Run the test suite
 
 ```bash
 $ npm test
@@ -243,35 +225,35 @@ $ npm test
 
 ### run the functional cases
 
-there are more exhaustive test cases included in `test/cases/`.
+There are more exhaustive test cases included in `test/cases/`.
 
-to run all the test cases:
+To run all the test cases:
 
 ```bash
 $ npm run funcs
 ```
 
-### generate a ~500,000 line test file
+### Generate a ~500,000 line test file
 
-this command requires the `data/wof.extract` file mentioned below in the 'building the database' section.
+This command requires the `data/wof.extract` file mentioned below in the 'building the database' section.
 
 ```bash
 $ npm run gentests
 ```
 
-once complete you can find the generated test cases in `test/cases/generated.txt`.
+Once complete you can find the generated test cases in `test/cases/generated.txt`.
 
 ---
 
-## docker
+## Docker
 
-### build the service image
+### Build the service image
 
 ```bash
 $ docker-compose build
 ```
 
-### run the service in the background
+### Run the service in the background
 
 ```bash
 $ docker-compose up -d
@@ -279,29 +261,37 @@ $ docker-compose up -d
 
 ---
 
-## building the database
+## Building the database
 
-### prerequisites
+### Prerequisites
 - jq 1.5+ must be installed
     - on ubuntu: `sudo apt-get install jq`
     - on mac: `brew install jq`
 - Who's on First data download
     - use the download script in [pelias/whosonfirst](https://github.com/pelias/whosonfirst#downloading-the-data)
 
+<<<<<<< 05c7c7d6f4a0f1e1333148cbff1ad7685b3d1b1e
 ### steps
 the database is created from geographic data sourced from the [whosonfirst](https://whosonfirst.org/) project.
+||||||| merged common ancestors
+### steps
+the database is created from geographic data sourced from the [whosonfirst](https://whosonfirst.mapzen.com/) project.
+=======
+### Steps
+The database is created from geographic data sourced from the [whosonfirst](https://whosonfirst.mapzen.com/) project.
+>>>>>>> Streamline documentation
 
-the whosonfirst project is distributed as geojson files, so in order to speed up development we first extract the relevant data in to a file: `data/wof.extract`.
+The whosonfirst project is distributed as geojson files, so in order to speed up development we first extract the relevant data in to a file: `data/wof.extract`.
 
-the following command will iterate over all the `geojson` files under the `WOF_DIR` path, extracting the relevant properties in to the file `data/wof.extract`.
+The following command will iterate over all the `geojson` files under the `WOF_DIR` path, extracting the relevant properties in to the file `data/wof.extract`.
 
-this process can take 30-60 minutes to run and consumes ~350MB of disk space, you will only need to run this command once, or when your local `whosonfirst-data` files are updated.
+This process can take 30-60 minutes to run and consumes ~350MB of disk space, you will only need to run this command once, or when your local `whosonfirst-data` files are updated.
 
 ```bash
 $ WOF_DIR=/data/whosonfirst-data/data npm run extract
 ```
 
-alternatively you can download the extract file from our s3 bucket:
+Alternatively you can download the extract file from our s3 bucket:
 
 ```bash
 $ mkdir data
@@ -320,7 +310,7 @@ $ npm run build
 
 ## Using the Docker image
 
-### rebuild the image
+### Rebuild the image
 
 you can rebuild the image on any system with the following command:
 
@@ -328,7 +318,7 @@ you can rebuild the image on any system with the following command:
 $ docker build -t pelias/placeholder .
 ```
 
-### download pre-built image
+### Download pre-built image
 
 Up to date Docker images are built and automatically pushed to Docker Hub from our continuous integration pipeline
 
@@ -338,7 +328,7 @@ You can pull the latest stable image with
 $ docker pull pelias/placeholder
 ```
 
-### download custom image tags
+### Download custom image tags
 
 We publish each commit and the latest of each branch to separate tags
 
@@ -346,13 +336,13 @@ A list of all available tags to download can be found at https://hub.docker.com/
 
 ---
 
-### uploading a new build to s3
+### Uploading a new build to s3
 
-this section is applicable to mapzen employees only and requires s3 credentials and the `aws` command to be installed and configured prior to running.
+This section is applicable to Pelias maintainers only and requires s3 credentials and the `aws` command to be installed and configured prior to running.
 
-other organizations may elect to change the bucket name in the config and utilize the same script.
+Other organizations may elect to change the bucket name in the config and utilize the same script.
 
-the script takes care of creating a date stamped archive and promoting the most recent build to the root of the bucket (with a public ACL).
+The script takes care of creating a date stamped archive and promoting the most recent build to the root of the bucket (with a public ACL).
 
 ```bash
 $ AWS_PROFILE=nextzen ./cmd/s3_upload.sh

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/pelias/placeholder.svg)](https://greenkeeper.io/)
 
 Placeholder is a parser for text inputs that understands relationships. It
-knows, for example, that Paris is a `city` in a `country` called France.
+knows, for example, that Paris is a `city` in a `country` called France, and a completely separate Paris in a `region` called Texas, in a `country` called The United States.
 
 This allows for Placeholder to assist Pelias in parsing queries that might be
 ambiguous without that understanding. Placeholder can also serve as a fully


### PR DESCRIPTION
This is a reorganizing of the Placeholder documentation with the goal
of allowing for new users to quickly understand the need for, and how to
install, Placeholder.

To that end, the initial description and installation instructions have
been made more concise, with the more detailed info moved further down
in the readme.

Additionally, capitalization has been fixed.