### PR TITLE
Use server start script instead of NPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ADD . ${WORKDIR}
 ENV WOF_DIR '/data/whosonfirst/data'
 ENV PLACEHOLDER_DATA '/data/placeholder'
 
-CMD [ "npm", "start" ]
+CMD [ "./cmd/server.sh" ]

--- a/cmd/server.sh
+++ b/cmd/server.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec node server/http.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "integration": "node test/integration.js | tap-spec",
     "funcs": "for case in test/cases/*.txt; do node test/case.js $case; done",
     "all": "npm run units && npm run integration && npm run funcs",
-    "start": "node server/http.js",
+    "start": "./cmd/server.sh",
     "extract": "bash ./cmd/extract.sh",
     "build": "bash ./cmd/build.sh",
     "gentests": "cat data/wof.extract | node cmd/generate_tests.js > test/cases/generated.txt",


### PR DESCRIPTION
As mentioned in https://github.com/pelias/api/pull/1096 and https://github.com/npm/npm/issues/4603, `npm start` is not the preferred way to start services in a Docker container. There are now several reasons:

1. `npm` does not properly handle signals making it harder to stop/kill
containers (containers which do not respond immediately to `SIGTERM` will be killed afte 10 seconds by `SIGKILL`)
2. `npm` attempts to write to disk, making it impossible to use with a read only root filesystem (which is a good security-conscious best practice for use with containers).

This change creates a server script which starts Placeholder appropriately, and uses that in the Dockerfile. To avoid duplicating knowledge of how to start Placeholder, `npm start` uses it as well.