### PR TITLE
Use NODE_ENV ARG to control NPM install and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM pelias/baseimage
 # note: this is done in one command in order to keep down the size of intermediate containers
 RUN apt-get update && apt-get install -y build-essential python jq && rm -rf /var/lib/apt/lists/*
 
+# default to development, production builds can change this with a build arg
+ARG NODE_ENV=development
+
 # change working dir
 ENV WORKDIR /code/pelias/placeholder
 WORKDIR ${WORKDIR}
@@ -15,6 +18,9 @@ RUN npm install
 
 # copy code from local checkout
 ADD . ${WORKDIR}
+
+# run tests if not building a production image
+RUN if [ "$NODE_ENV" != "production" ]; then npm test; fi
 
 ENV WOF_DIR '/data/whosonfirst/data'
 ENV PLACEHOLDER_DATA '/data/placeholder'


### PR DESCRIPTION
By using the Dockerfile [ARG](https://docs.docker.com/engine/reference/builder/#arg) directive, we can set an ENV variable and control it via the `--build-arg` parameter to `docker build`.

Using this we can configure the Dockerfile to skip installing NPM dev dependencies and running unit tests.

In my testing this reduces the size of the Placeholder docker images from 290MB to 200MB, which is pretty huge! It reduces the time to build the image, reduces our surface area for security issues, and seems like an all around win.