### PR TITLE
feat(findbyid): add type check for lang HTTP param

### DIFF
--- a/server/routes/findbyid.js
+++ b/server/routes/findbyid.js
@@ -11,7 +11,7 @@ module.exports = function( req, res ){
   });
 
   var lang;
-  if( req.query.lang && req.query.lang.length === 3 ){
+  if( 'string' === typeof req.query.lang && req.query.lang.length === 3 ){
     lang = req.query.lang.toLowerCase();
   }
 
@@ -23,7 +23,10 @@ module.exports = function( req, res ){
     var docs = {};
     for( var i=0; i<documents.length; i++ ){
       var result = documents[i];
-      // Send only wanted lang
+
+      // return only the single language requested by the user
+      // or, if not available, return all languages.
+      // ref: https://github.com/pelias/placeholder/pull/128
       const translation = result.names[lang];
       if ( Array.isArray(translation) ) {
         result.names = {};

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -32,7 +32,7 @@ module.exports = function( req, res ){
 
     // language property
     var lang;
-    if( req.query.lang && req.query.lang.length === 3 ){
+    if( 'string' === typeof req.query.lang && req.query.lang.length === 3 ){
       lang = req.query.lang.toLowerCase();
     }
 


### PR DESCRIPTION
adding this because it's possible to have `express` interpret the input param `?lang=string` as an Array using the URL scheme `?lang[]=element1&lang[]=element2`.

added a link to the PR for controlling the language code.