### PR TITLE
feat(docker): run as pelias user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ ADD . ${WORKDIR}
 ENV WOF_DIR '/data/whosonfirst/data'
 ENV PLACEHOLDER_DATA '/data/placeholder'
 
+USER pelias
+
 CMD [ "./cmd/server.sh" ]


### PR DESCRIPTION
This uses the work in https://github.com/pelias/baseimage/pull/2 to run processes as the `pelias` user. Running as a non-root user is ideal from a security perspective.