### PR TITLE
feat(test): Use test running binary to catch errors

### DIFF
--- a/cmd/integration
+++ b/cmd/integration
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+node test/integration.js | npx tap-spec

--- a/cmd/units
+++ b/cmd/units
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+node test/units.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "main": "server.js",
   "scripts": {
     "test": "npm run units",
-    "units": "node test/units.js | tap-spec",
-    "integration": "node test/integration.js | tap-spec",
+    "units": "./cmd/units",
+    "integration": "./cmd/integration",
     "funcs": "for case in test/cases/*.txt; do node test/case.js $case; done",
     "all": "npm run units && npm run integration && npm run funcs",
     "start": "./cmd/server.sh",


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail` option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744