### PR TITLE
wof property wof:abbreviation was renamed wof:shortcode

### DIFF
--- a/cmd/jq.filter
+++ b/cmd/jq.filter
@@ -1,6 +1,6 @@
 .properties | with_entries(
   select( .key |
-    test("^wof:(id|name|placetype|hierarchy|parent_id|country_alpha3|abbreviation|superseded_by|label|population|megacity)$"),
+    test("^wof:(id|name|placetype|hierarchy|parent_id|country_alpha3|abbreviation|shortcode|superseded_by|label|population|megacity)$"),
     test("^lbl:(bbox|latitude|longitude)$"),
     test("^geom:(area|bbox|latitude|longitude)$"),
     test("^iso:(country)$"),
@@ -13,6 +13,7 @@
     test("^wk:(population)$"),
     test("^meso:(pop)$"),
     test("^statoids:(population)$"),
-    test("^name:")
+    test("^name:"),
+    test("^abrv:")
   )
 )

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -62,8 +62,9 @@ function insertWofRecord( wof, next ){
     // add 'wof:name'
     tokens.push({ lang: 'und', tag: 'label', body: wof['wof:name'] });
 
-    // add 'wof:abbreviation'
-    tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:abbreviation'] });
+    // add 'wof:shortcode'
+    // @todo: wof:abbreviation is deprecated, remove references to it
+    tokens.push({ lang: 'und', tag: 'abbr', body: wof['wof:shortcode'] || wof['wof:abbreviation'] });
 
     // add 'ne:abbrev'
     // tokens.push({ lang: 'und', body: wof['ne:abbrev'] });
@@ -282,11 +283,12 @@ function getPopulation( wof ) {
 
 // abbreviations and ISO codes
 // logic copied from: pelias/whosonfirst src/components/extractFields.js (since modified)
+// @todo: wof:abbreviation is deprecated, remove references to it
 function getAbbreviation( wof ) {
   if( 'country' === wof['wof:placetype'] || 'dependency' === wof['wof:placetype'] ) {
     return wof['wof:country_alpha3'] || wof['ne:iso_a3'];
-  } else if( wof['wof:abbreviation'] ) {
-    return wof['wof:abbreviation'];
+  } else if( wof['wof:shortcode'] || wof['wof:abbreviation'] ) {
+    return wof['wof:shortcode'] || wof['wof:abbreviation'];
   }
 }
 

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -144,7 +144,7 @@ module.exports.store_abbr = function(test, util) {
     mock.insertWofRecord(params({
       'wof:placetype': 'country',
       'wof:country_alpha3': 'TEST',
-      'wof:abbreviation': 'TEST2'
+      'wof:shortcode': 'TEST2'
     }), function(){
       t.deepEqual( mock._calls.set[0][1].abbr, 'TEST');
       t.end();
@@ -461,50 +461,65 @@ module.exports.getAbbreviation = function(test, util) {
 
     t.equal( undefined, wof.getAbbreviation({
       'wof:placetype': 'country',
-      'wof:abbreviation': 'TEST2'
+      'wof:shortcode': 'TEST2'
     }));
     t.equal( undefined, wof.getAbbreviation({
       'wof:placetype': 'dependency',
-      'wof:abbreviation': 'TEST2'
+      'wof:shortcode': 'TEST2'
     }));
 
     t.equal( 'TEST', wof.getAbbreviation({
       'wof:placetype': 'country',
       'wof:country_alpha3': 'TEST',
-      'wof:abbreviation': 'TEST2'
+      'wof:shortcode': 'TEST2'
     }));
     t.equal( 'TEST', wof.getAbbreviation({
       'wof:placetype': 'dependency',
       'wof:country_alpha3': 'TEST',
-      'wof:abbreviation': 'TEST2'
+      'wof:shortcode': 'TEST2'
     }));
 
     t.equal( 'TEST', wof.getAbbreviation({
       'wof:placetype': 'country',
       'ne:iso_a3': 'TEST',
-      'wof:abbreviation': 'TEST2'
+      'wof:shortcode': 'TEST2'
     }));
     t.equal( 'TEST', wof.getAbbreviation({
       'wof:placetype': 'dependency',
       'ne:iso_a3': 'TEST',
-      'wof:abbreviation': 'TEST2'
+      'wof:shortcode': 'TEST2'
     }));
 
     t.equal( 'TEST', wof.getAbbreviation({
       'wof:placetype': 'country',
       'wof:country_alpha3': 'TEST',
       'ne:iso_a3': 'TEST2',
-      'wof:abbreviation': 'TEST3'
+      'wof:shortcode': 'TEST3'
     }));
     t.equal( 'TEST', wof.getAbbreviation({
       'wof:placetype': 'dependency',
       'wof:country_alpha3': 'TEST',
       'ne:iso_a3': 'TEST2',
-      'wof:abbreviation': 'TEST3'
+      'wof:shortcode': 'TEST3'
     }));
     t.end();
   });
 
+  test( 'wof:shortcode', function(t) {
+    t.equal( 'TEST2', wof.getAbbreviation({
+      'ne:iso_a3': 'TEST',
+      'wof:shortcode': 'TEST2'
+    }));
+    t.equal( 'TEST2', wof.getAbbreviation({
+      'ne:iso_a3': 'TEST',
+      'wof:shortcode': 'TEST2'
+    }));
+    t.end();
+  });
+
+  // backwards compatibility for wof:abbreviation
+  // note: this property is deprecated, the code can be
+  // removed in the future.
   test( 'wof:abbreviation', function(t) {
     t.equal( 'TEST2', wof.getAbbreviation({
       'ne:iso_a3': 'TEST',
@@ -613,10 +628,10 @@ module.exports.add_token = function(test, util) {
     });
   });
 
-  test( 'wof:abbreviation', function(t) {
+  test( 'wof:shortcode', function(t) {
     var mock = new Mock();
     mock.insertWofRecord(params({
-      'wof:abbreviation': 'EXAMPLE'
+      'wof:shortcode': 'EXAMPLE'
     }), function(){
       t.deepEqual( mock._calls.setTokens[0][0], 1 );
       t.deepEqual( mock._calls.setTokens[0][1], [


### PR DESCRIPTION
wof property `wof:abbreviation` was renamed `wof:shortcode`.

we will need to leave both the old and new fields in the code in case users would like to build from new code against old data.

after a period of >1 month we should remove the now deprecated `wof:abbreviation` property

- https://github.com/pelias/placeholder/issues/138
- https://github.com/whosonfirst/whosonfirst-properties/issues/78