### PR TITLE
feat(blacklist-stream): allow excluding documents via GID blacklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.4",
     "lower-case": "^1.1.4",
     "morgan": "^1.9.0",
+    "pelias-blacklist-stream": "^1.1.0",
     "pelias-logger": "^1.2.1",
     "remove-accents": "^0.4.0",
     "require-dir": "^1.0.0",

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -2,6 +2,8 @@
 // plugin for whosonfirst
 const _ = require('lodash'),
     dir = require('require-dir'),
+    util = require('util'),
+    blacklist = require('pelias-blacklist-stream/loader')(),
     analysis = require('../lib/analysis'),
     language = dir('../config/language');
 
@@ -17,6 +19,10 @@ function insertWofRecord( wof, next ){
 
   // sanity check; because WOF
   if( !isValidWofRecord( id, wof ) ) { return next(); }
+
+  // enforce pelias/blacklist-stream exclusions
+  let peliasGID = util.format('whosonfirst:%s:%d', wof['wof:placetype'], id);
+  if( blacklist && blacklist.hasOwnProperty( peliasGID ) ) { return next(); }
 
   // --- document which will be saved in the doc store ---
 


### PR DESCRIPTION
This PR includes a new stream called [blacklist-stream](https://github.com/pelias/blacklist-stream) which allows records to be excluded from the build.

See https://github.com/pelias/blacklist-stream for more information on how to use the blacklist file.