### PR TITLE
rebuild databases

### DIFF
--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -15,17 +15,17 @@
 890442097 Hamilton, Bermuda
 421188863 Bandar Seri Begawan, Brunei
 101964877 Brasilia, Brazil
-421174929 Gaborone, Botswana
+85669631 Gaborone, Botswana
 890442105 Belmopan, Belize
 101735873 Ottawa, Canada
-890417321 West Island, Cocos Islands
+101938929 West Island, Cocos Islands
 421181445 Bangui, Central African Republic
 85670067 Brazzaville, Republic of the Congo
 101748453 Bern, Switzerland
 421168957 Yamoussoukro, Ivory Coast
 102016915 Santiago, Chile
 85670331 Praia, Cape Verde
-890442073 Willemstad, Curacao
+421187435 Willemstad, Curacao
 101748799 Berlin, Germany
 101749159 Copenhagen, Denmark
 890442101 Roseau, Dominica
@@ -35,13 +35,13 @@
 101748417 Helsinki, Finland
 101750367 London, United Kingdom
 890451719 St. George's, Grenada
-1091680781 Cayenne, French Guiana
+890442055 Cayenne, French Guiana
 1125821075 St Peter Port, Guernsey
 421168965 Accra, Ghana
 101753853 Gibraltar, Gibraltar
 101870623 Nuuk, Greenland
 421167921 Banjul, Gambia
-890444429 Conakry, Guinea
+421189675 Conakry, Guinea
 890420199 Basse-Terre, Guadeloupe
 421178347 Malabo, Equatorial Guinea
 421197943 Bissau, Guinea-Bissau
@@ -74,7 +74,7 @@
 85674093 Male, Maldives
 421168781 Lilongwe, Malawi
 102023407 Kuala Lumpur, Malaysia
-421172081 Windhoek, Namibia
+1141909361 Windhoek, Namibia
 890413117 Noumea, New Caledonia
 890440179 Kingston, Norfolk Island
 101751893 Amsterdam, Netherlands

--- a/test/cases/citySearch.txt
+++ b/test/cases/citySearch.txt
@@ -270,7 +270,7 @@
 85936243 Columbus, GA
 101712381 Columbus, OH
 85923663 Compton
-890444429 Conakry
+421189675 Conakry
 102017759 Concepcion
 85922187 Concord, CA
 85981159 Concord, NC
@@ -373,7 +373,7 @@
 101748709 Essen
 101716261 Eugene
 101723683 Euless
-85818323 Evanston
+1126087807 Evanston
 85818327 Evansville
 85867883 Everett
 85818511 Fairfield
@@ -601,7 +601,7 @@
 101752117 Krakow
 102015579 Krasnodar
 102013953 Krasnoyarsk
-101748683 Krefeld
+1175611403 Krefeld
 85784291 Kuala Lumpur
 85672703 Kumamoto
 421168961 Kumasi
@@ -644,7 +644,7 @@
 85894325 Lexington
 85947137 Lexington-Fayette
 101750277 Lille
-85675925 Lima
+1175613121 Lima
 101749501 Limoges
 85830585 Lincoln
 101752291 Linkoping
@@ -687,7 +687,7 @@
 102010515 Magnitogorsk
 101750341 Maidstone
 102018665 Makassar
-102016749 Makhachkala
+1175613531 Makhachkala
 101748185 Malaga
 85950349 Malden
 85675495 Managua
@@ -766,7 +766,7 @@
 102030609 Mumbai
 85941463 Muncie
 101723111 Murfreesboro
-102001881 Murmansk
+1175613487 Murmansk
 85923375 Murrieta
 85679655 Mwanza
 102009155 Naberezhnyye Chelny
@@ -816,7 +816,7 @@
 85838305 Northridge
 85923497 Norwalk
 101750483 Norwich
-101750491 Nottingham
+1175612705 Nottingham
 101953095 Nova Iguacu
 85922017 Novato
 404508281 Novi
@@ -884,7 +884,7 @@
 101751663 Pecs
 85932299 Pembroke Pines
 85933005 Pensacola
-102004419 Penza
+1175613505 Penza
 85917343 Peoria
 102008455 Perm
 85923353 Perris
@@ -940,14 +940,14 @@
 85923937 Rancho Cucamonga
 101749161 Randers
 101721605 Rapid City
-101914059 Reading, England
+1175612721 Reading, England
 85950649 Reading, MA
 102056781 Recife
 101748751 Recklinghausen
 85923859 Redding
 101750455 Redditch
 85844131 Redlands
-85844149 Redmond
+1126067701 Redmond
 85923467 Redondo Beach
 85922447 Redwood City
 101751377 Reims
@@ -991,7 +991,7 @@
 101750835 Saint-Etienne
 85672807 Saitama
 102031413 Sakai
-101750555 Salford
+1175612693 Salford
 85922603 Salinas
 101728075 Salt Lake City
 102000871 Saltillo
@@ -1027,7 +1027,7 @@
 101996369 Santiago de Queretaro
 85670553 Santo Domingo
 890518775 Sarajevo
-102010031 Saransk
+1175613527 Saransk
 85932709 Sarasota
 102011123 Saratov
 85936939 Savannah
@@ -1071,7 +1071,7 @@
 101728055 South Jordan
 85849939 South Peabody
 101750613 South Shields
-102018849 South Tangerang
+1276601603 South Tangerang
 1125818773 South Vineland
 85850209 South Whittier
 101913905 Southampton
@@ -1102,7 +1102,7 @@
 101913969 Stockport
 85923257 Stockton
 101750603 Stockton-on-Tees
-101913981 Stoke-on-Trent
+1175612703 Stoke-on-Trent
 101751113 Strasbourg
 101912539 Subotica
 102031367 Suita
@@ -1244,7 +1244,7 @@
 85877207 Whittier
 404504929 Wichita
 101748579 Wiesbaden
-890442073 Willemstad
+421187435 Willemstad
 85931573 Wilmington, DE
 85950663 Wilmington, MA
 85871353 Windsor

--- a/test/functional.js
+++ b/test/functional.js
@@ -10,7 +10,7 @@ module.exports.functional = function(test, util) {
   var assert = runner.bind(null, test, ph);
 
   assert('Kelburn Wellington New Zealand', [85772991]);
-  assert('North Sydney', [85771181, 85784821, 101931469, 102048877, 404225393]);
+  assert('North Sydney', [85771181, 85784821, 101931469, 102048877, 404225393, 1310698409]);
   assert('Sydney New South Wales Australia', [101932003, 102049151, 404226357]);
   assert('ケープタウン 南アフリカ', [101928027]);
   assert('경기도 광명시', [890472589]);
@@ -31,9 +31,9 @@ module.exports.functional = function(test, util) {
   assert('lancaster lancaster pa', [ 101718643, 404487183, 404487185 ]);
 
   // assertions from pelias acceptance-test suite
-  assert('灣仔, 香港', [85671779]);
+  assert('灣仔, 香港', [85671779, 1243098523]);
   assert('new york city, usa', [85977539]);
-  assert('sendai, japan', [102031919, 1108739995, 1125901991]);
+  assert('sendai, japan', [102031919, 1108739995, 1125901991, 1243269829]);
   assert('Észak-Alföld', [404227483]);
   assert('Comunidad Foral De Navarra, ES', [404227391]);
   assert('Île-De-France, France', [404227465]);

--- a/test/functional_autocomplete.js
+++ b/test/functional_autocomplete.js
@@ -9,8 +9,8 @@ module.exports.functional = function(test, util) {
 
   var assert = runner.bind(null, test, ph);
 
-  assert('Kelbur\x26', [85772991]);
-  assert('Kelburn\x26', [85772991]);
+  assert('Kelbur\x26', [85772991, 1326645067]);
+  assert('Kelburn\x26', [85772991, 1326645067]);
   assert('Kelburn W\x26', [85772991]);
   assert('Kelburn Well\x26', [85772991]);
   assert('Kelburn Wellington\x26', [85772991]);

--- a/test/prototype/query_integration.js
+++ b/test/prototype/query_integration.js
@@ -10,7 +10,7 @@ module.exports.query = function(test, util) {
   var assert = runner.bind(null, test, ph);
 
   assert([['kelburn', 'wellington', 'new zealand']], [85772991]);
-  assert([['north sydney']], [85771181, 85784821, 101931469, 102048877, 404225393]);
+  assert([['north sydney']], [85771181, 85784821, 101931469, 102048877, 404225393, 1310698409]);
   assert([['sydney', 'new south wales', 'australia']], [101932003, 102049151, 404226357]);
   assert([['ケープタウン', '南アフリカ']], [101928027]);
 };

--- a/test/prototype/tokenize_integration.js
+++ b/test/prototype/tokenize_integration.js
@@ -23,7 +23,7 @@ module.exports.tokenize = function(test, util) {
   // see: https://github.com/pelias/placeholder/issues/28
   // note: the 'Le Cros-d’Utelle, France' example (as at 20-09-17) no longer dedupes
   // to a single grouping due to the introduction of the token 'le' from 85685547
-  assert('Le Cros-d’Utelle, France', [['le','france'],['le cros','d','utelle','france']]);
+  assert('Le Cros-d’Utelle, France', [['le crosdutelle', 'france' ], [ 'le cros d utelle', 'france']]);
   assert('luxemburg luxemburg', [['luxemburg', 'luxemburg']]); // does not remove duplicate tokens
 
   // ambiguous parses


### PR DESCRIPTION
rebuild databases with data from Jan 18th 2019 (data was generated directly from a repo clone)
update tests to reflect superceded and deprecated equivalents

note: the database and extract files have grown significantly in size since the recent import of additional geonames data in to WOF.

published:

```
➜  placeholder git:(rebuild) ✗ AWS_PROFILE=nextzen ./cmd/s3_upload.sh
--- gzipping data files ---
--- uploading archive ---
upload: data/store.sqlite3.gz to s3://pelias-data.nextzen.org/placeholder/archive/2019-01-28/store.sqlite3.gz
upload: data/wof.extract.gz to s3://pelias-data.nextzen.org/placeholder/archive/2019-01-28/wof.extract.gz
--- list remote archive ---
2019-01-28 14:33:43    1.3 GiB store.sqlite3.gz
2019-01-28 14:45:36  347.8 MiB wof.extract.gz

> would you like to promote this build to production (yes/no)?
yes
--- promoting build to production ---
copy: s3://pelias-data.nextzen.org/placeholder/archive/2019-01-28/store.sqlite3.gz to s3://pelias-data.nextzen.org/placeholder/store.sqlite3.gz
copy: s3://pelias-data.nextzen.org/placeholder/archive/2019-01-28/wof.extract.gz to s3://pelias-data.nextzen.org/placeholder/wof.extract.gz
--- list remote production files ---
                           PRE archive/
                           PRE master/
                           PRE production/
                           PRE staging/
2019-01-28 14:49:37    1.3 GiB store.sqlite3.gz
2019-01-28 14:49:59  347.8 MiB wof.extract.gz
```