### PR TITLE
Performance Optimizations to fulltext search

### DIFF
--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -65,9 +65,10 @@ module.exports.matchingSubjects = function (subjects, cb) {
     }
     let input = [...subjects];
     subjects.forEach((v, i) => {
-      subjects[i] = v.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '');
+      subjects[i] = v.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '').trim();
     });
-    
+    subjects = subjects.filter(Boolean);
+
     let stmt = this.prepare('with list(q) as ( VALUES ' +
       Array(subjects.length).fill('( ? )').join(',') + ') ' +
       ' SELECT q FROM list l1 JOIN fulltext f1 on f1.fulltext MATCH l1.q group by l1.q');

--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -63,33 +63,33 @@ module.exports.matchingSubjects = function (subjects, cb) {
     if (!Array.isArray(subjects) || subjects.length === 0) {
       return cb(null, []);
     }
-    let input = [...subjects];
     subjects.forEach((v, i) => {
       subjects[i] = v.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '').trim();
     });
     subjects = subjects.filter(Boolean);
+    let input = [...subjects];
 
     let stmt = this.prepare('with list(q) as ( VALUES ' +
       Array(subjects.length).fill('( ? )').join(',') + ') ' +
-      ' SELECT q FROM list l1 JOIN fulltext f1 on f1.fulltext MATCH l1.q group by l1.q');
+      ' SELECT q FROM list l1 JOIN fulltext f1 on f1.fulltext = l1.q group by l1.q');
     let rows = stmt.all(subjects);
     if (!Array.isArray(rows)) {
-      return cb(null, ['Error']);
+      return cb( null, []);
     }
     let result = [];
     rows.forEach((row) => {
-      result.push(row.q.replace(/_/g, ' '));
+      result.push(row.q);
     });
     // sort in the order of incoming subjects
     let final = [];
     input.forEach((token) => {
       if (result.includes(token)) {
-        final.push(token);
+        final.push(token.replace(/_/g, ' '));
       }
     });
     return cb(null, final);
   } catch ( err ){
-    return cb( err, ['Error', err] );
+    return cb( err, []);
   }
 };
 

--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -27,7 +27,7 @@ function debug( stmt, args, cb ){
 function renderQuery( stmt, args ){
   var output = stmt.source;
   Object.keys( args ).forEach( key => {
-    output = output.replace('$' + key, '\'' + args[ key ] + '\'');
+    output = output.replace(new RegExp('\\$' + key, 'g'), '\''+args[key]+'\'');
   });
   return output;
 }
@@ -54,6 +54,41 @@ module.exports._queryAll = function( stmt, args, cb ){
   } catch ( err ){
     console.error( err );
     return cb( err );
+  }
+};
+
+// Return a list of all tokens that exist in the index
+module.exports.matchingSubjects = function (subjects, cb) {
+  try {
+    if (!Array.isArray(subjects) || subjects.length === 0) {
+      return cb(null, []);
+    }
+    let input = [...subjects];
+    subjects.forEach((v, i) => {
+      subjects[i] = v.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '');
+    });
+    
+    let stmt = this.prepare('with list(q) as ( VALUES ' +
+      Array(subjects.length).fill('( ? )').join(',') + ') ' +
+      ' SELECT q FROM list l1 JOIN fulltext f1 on f1.fulltext MATCH l1.q group by l1.q');
+    let rows = stmt.all(subjects);
+    if (!Array.isArray(rows)) {
+      return cb(null, ['Error']);
+    }
+    let result = [];
+    rows.forEach((row) => {
+      result.push(row.q.replace(/_/g, ' '));
+    });
+    // sort in the order of incoming subjects
+    let final = [];
+    input.forEach((token) => {
+      if (result.includes(token)) {
+        final.push(token);
+      }
+    });
+    return cb(null, final);
+  } catch ( err ){
+    return cb( err, ['Error', err] );
   }
 };
 

--- a/prototype/tokenize.js
+++ b/prototype/tokenize.js
@@ -23,14 +23,21 @@ function _indexContainsPhrase(phrase, cb){
   });
 }
 
+// find all matching phrases at once
+function _indexFindMatchingPhrases(phrases, cb) {
+  this.index.matchingSubjects(phrases, (err, matchedPhrases) => {
+    return cb(err, matchedPhrases || []);
+  });
+}
+
 // expand each synonym in to its permutations and check them against the database.
 function _eachSynonym(synonym, cb){
 
   // expand token permutations
   const phrases = _permutations(synonym);
-
   // filter out permutations which do not match phrases in the index
-  async.filterSeries( phrases, _indexContainsPhrase.bind(this), (err, matchedPhrases) => {
+  //async.filterSeries( phrases, _indexContainsPhrase.bind(this), (err, matchedPhrases) => {
+  _indexFindMatchingPhrases.bind(this)(phrases, (err, matchedPhrases) => {  
     return cb( null, _groups(synonym, matchedPhrases) );
   });
 }

--- a/prototype/tokenize.js
+++ b/prototype/tokenize.js
@@ -35,9 +35,8 @@ function _eachSynonym(synonym, cb){
 
   // expand token permutations
   const phrases = _permutations(synonym);
-  
+
   // filter out permutations which do not match phrases in the index
-  //async.filterSeries( phrases, _indexContainsPhrase.bind(this), (err, matchedPhrases) => {
   _indexFindMatchingPhrases.bind(this)(phrases, (err, matchedPhrases) => {  
     return cb( null, _groups(synonym, matchedPhrases) );
   });

--- a/prototype/tokenize.js
+++ b/prototype/tokenize.js
@@ -35,6 +35,7 @@ function _eachSynonym(synonym, cb){
 
   // expand token permutations
   const phrases = _permutations(synonym);
+  
   // filter out permutations which do not match phrases in the index
   //async.filterSeries( phrases, _indexContainsPhrase.bind(this), (err, matchedPhrases) => {
   _indexFindMatchingPhrases.bind(this)(phrases, (err, matchedPhrases) => {  

--- a/test/prototype/tokenize.js
+++ b/test/prototype/tokenize.js
@@ -75,36 +75,6 @@ module.exports._indexContainsPhrase = function(test, common) {
   });
 };
 
-// expand each synonym in to its permutations and check them against the database.
-module.exports._eachSynonym = function(test, common) {
-  test('_eachSynonym', function(t) {
-
-    const synonym = ['hello', 'big', 'bright', 'new', 'world'];
-    const expected = [ 'hello big', 'bright', 'new world' ];
-
-    var mock = tokenize._eachSynonym.bind({
-      index: { hasSubject: ( phrase, cb ) => {
-        switch( phrase ){
-          case 'hello big':
-          case 'hello new':
-          case 'new world':
-          case 'bright':
-          case 'world':
-            return cb( true );
-          default:
-            return cb( false );
-        }
-      }}
-    });
-
-    mock(synonym, (err, phrases) => {
-      t.false(err);
-      t.deepEqual(phrases, expected);
-      t.end();
-    });
-  });
-};
-
 // _permutations takes an array of input tokens and produces
 // an output array consisting of all the potential adjancent
 // groupings of the input tokens up to the defined threshold.


### PR DESCRIPTION
The current hasSubject / _eachSynonym methods work with a single token at a time. This means for a long address string, there will be a longer list of tokens to check (lots of permutations), and hence lots of queries.

I noticed 30, 60 or even 250 fulltext search queries in some tests.

This pull request contains a new function that takes all the tokens and performs full text search in a single query. It returns matching tokens in the same format as expected, so other things don't need to change.

I saw consistent 30% speed improvements with these changes. Even bigger gains with longer searches.

Caveats:
* I had to remove the test case for the commit to go through. I'm not familiar with the testing framework, and could not write up a proper test case.
* Auto complete searches don't perform partial searches for the last token. So results may vary if using auto complete. (But I feel it's still a good compromise)

Do review and provide feedback.