### PR TITLE
feat(dirs): Update directories to work with bundles/sqlite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm install
 # copy code from local checkout
 ADD . ${WORKDIR}
 
-ENV WOF_DIR '/data/whosonfirst/data'
+ENV WOF_DIR '/data/whosonfirst'
 ENV PLACEHOLDER_DATA '/data/placeholder'
 
 USER pelias

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ the following command will iterate over all the `geojson` files under the `WOF_D
 this process can take 30-60 minutes to run and consumes ~350MB of disk space, you will only need to run this command once, or when your local `whosonfirst-data` files are updated.
 
 ```bash
-$ WOF_DIR=/data/whosonfirst-data/data npm run extract
+$ WOF_DIR=/data/whosonfirst-data npm run extract
 ```
 
 now you can rebuild the `data/store.json` file with the following command:

--- a/cmd/extract.sh
+++ b/cmd/extract.sh
@@ -8,7 +8,8 @@ mkdir -p ${PLACEHOLDER_DATA};
 
 echo "Creating extract at ${PLACEHOLDER_DATA}/wof.extract"
 
-if [ "$1" = "sqlite" ]; then
+SQLITE="$(node -e "console.log(require('pelias-config').generate().imports.whosonfirst.sqlite === true)")"
+if [ "$SQLITE" = "true" ]; then
   exec node --max_old_space_size=8000 ${DIR}/wof_extract_sqlite.js > ${PLACEHOLDER_DATA}/wof.extract;
 else
   ${DIR}/wof_extract.sh > ${PLACEHOLDER_DATA}/wof.extract;

--- a/cmd/extract.sh
+++ b/cmd/extract.sh
@@ -9,7 +9,7 @@ mkdir -p ${PLACEHOLDER_DATA};
 echo "Creating extract at ${PLACEHOLDER_DATA}/wof.extract"
 
 if [ "$1" = "sqlite" ]; then
-  exec node --max_old_space_size=4096 ${DIR}/wof_extract_sqlite.js > ${PLACEHOLDER_DATA}/wof.extract;
+  exec node --max_old_space_size=8000 ${DIR}/wof_extract_sqlite.js > ${PLACEHOLDER_DATA}/wof.extract;
 else
   ${DIR}/wof_extract.sh > ${PLACEHOLDER_DATA}/wof.extract;
 fi

--- a/cmd/extract.sh
+++ b/cmd/extract.sh
@@ -8,6 +8,10 @@ mkdir -p ${PLACEHOLDER_DATA};
 
 echo "Creating extract at ${PLACEHOLDER_DATA}/wof.extract"
 
-${DIR}/wof_extract.sh > ${PLACEHOLDER_DATA}/wof.extract;
+if [ "$1" = "sqlite" ]; then
+  exec node --max_old_space_size=4096 ${DIR}/wof_extract_sqlite.js > ${PLACEHOLDER_DATA}/wof.extract;
+else
+  ${DIR}/wof_extract.sh > ${PLACEHOLDER_DATA}/wof.extract;
+fi
 
 echo 'Done!'

--- a/cmd/wof_extract.sh
+++ b/cmd/wof_extract.sh
@@ -6,7 +6,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 
 # location of whosonfirst data dir
 # note: set WOF_DIR env var to override
-WOF_DIR=${WOF_DIR:-'/data/whosonfirst-data/data'};
+WOF_DIR=${WOF_DIR:-'/data/whosonfirst-data'};
 
 # requires command: jq - Command-line JSON processor
 # on ubuntu: sudo apt-get install jq
@@ -42,7 +42,7 @@ function placetypeFilter {
 
 # extract only the json properies from each file (eg: excluding zs:*)
 # note: excludes 'alt' geometeries
-find "${WOF_DIR}" -type f -name '*.geojson' |\
+find "${WOF_DIR}/data" -type f -name '*.geojson' |\
   grep -E '/[0-9]+\.geojson$' |\
   placetypeFilter |\
   ${XARGS_CMD} ${JQ_BIN} -c -M -f "${DIR}/jq.filter";

--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -40,7 +40,7 @@ const output = () => {
 };
 
 new SQLiteStream(
-  path.join(WOF_DIR, 'whosonfirst-data-latest.db'),
+  path.join(WOF_DIR, 'sqlite', 'whosonfirst-data-latest.db'),
   SQLiteStream.findGeoJSONByPlacetype(layers)
 )
   .pipe(whosonfirst.toJSONStream())

--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -1,45 +1,53 @@
-#!/usr/bin/env node
 const path = require('path');
+const fs = require('fs');
 const whosonfirst = require('pelias-whosonfirst');
 const SQLiteStream = whosonfirst.SQLiteStream;
 const through = require('through2');
 const Placeholder = require('../Placeholder');
 
-const WOF_DIR = process.env.WOF_DIR || '/data/whosonfirst-data/data';
-const layers = [
-  'ocean',
-  'continent',
-  'marinearea',
-  'empire',
-  'country',
-  'dependency',
-  'disputed',
-  'macroregion',
-  'region',
-  'macrocounty',
-  'county',
-  'localadmin',
-  'locality',
-  'borough',
-  'macrohood',
-  'neighbourhood'
-];
-const ph = new Placeholder();
-ph.load({ reset: true });
+const WOF_DIR = process.env.WOF_DIR || '/data/whosonfirst-data/sqlite';
+
+const layers = fs.readFileSync(path.join(__dirname, 'placetype.filter'), 'utf-8')
+                  .replace(/^.*\(/, '') // Removes all characters before the first parenthesis
+                  .match(/[a-z]+/g); // Get the layer list
+
+const jq_filter = fs.readFileSync(path.join(__dirname, 'jq.filter'), 'utf-8')
+                    .match(/test\("(.*)"\)/g) // Get all tests
+                    .map(s => s.replace(/^[^"]+"/, '').replace(/"[^"]+$/, '')) // Get only regex part
+                    .map(s => new RegExp(s)); // Transform it into JS RegExp
+
+const output = () => {
+  if (process.argv.length > 2 && process.argv[2] === 'build') {
+    const ph = new Placeholder();
+    ph.load({ reset: true });
+    return through.obj((row, _, next) => {
+      ph.insertWofRecord(row, next);
+    }, done => {
+      console.error('populate fts...');
+      ph.populate();
+      console.error('optimize...');
+      ph.optimize();
+      console.error('close...');
+      ph.close();
+      done();
+    });
+  } else {
+    return through.obj((row, _, next) => {
+      console.log(JSON.stringify(row));
+      next();
+    });
+  }
+};
 
 new SQLiteStream(
-  path.join(WOF_DIR, 'sqlite', 'whosonfirst-data-latest.db'),
+  path.join(WOF_DIR, 'whosonfirst-data-latest.db'),
   SQLiteStream.findGeoJSONByPlacetype(layers)
 )
   .pipe(whosonfirst.toJSONStream())
   .pipe(through.obj((row, _, next) => {
-    ph.insertWofRecord(row.properties, next);
-  }, done => {
-    console.error('populate fts...');
-    ph.populate();
-    console.error('optimize...');
-    ph.optimize();
-    console.error('close...');
-    ph.close();
-    done();
-  }));
+    Object.keys(row.properties)
+          .filter(key => !jq_filter.some(regex => regex.test(key)))
+          .forEach(key => delete row.properties[key]);
+    next(null, row.properties);
+  }))
+  .pipe(output());

--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const path = require('path');
+const whosonfirst = require('pelias-whosonfirst');
+const SQLiteStream = whosonfirst.SQLiteStream;
+const through = require('through2');
+const Placeholder = require('../Placeholder');
+
+const WOF_DIR = process.env.WOF_DIR || '/data/whosonfirst-data/data';
+const layers = [
+  'ocean',
+  'continent',
+  'marinearea',
+  'empire',
+  'country',
+  'dependency',
+  'disputed',
+  'macroregion',
+  'region',
+  'macrocounty',
+  'county',
+  'localadmin',
+  'locality',
+  'borough',
+  'macrohood',
+  'neighbourhood'
+];
+const ph = new Placeholder();
+ph.load({ reset: true });
+
+new SQLiteStream(
+  path.join(WOF_DIR, 'sqlite', 'whosonfirst-data-latest.db'),
+  SQLiteStream.findGeoJSONByPlacetype(layers)
+)
+  .pipe(whosonfirst.toJSONStream())
+  .pipe(through.obj((row, _, next) => {
+    ph.insertWofRecord(row.properties, next);
+  }, done => {
+    console.error('populate fts...');
+    ph.populate();
+    console.error('optimize...');
+    ph.optimize();
+    console.error('close...');
+    ph.close();
+    done();
+  }));

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "morgan": "^1.9.0",
     "pelias-blacklist-stream": "^1.1.0",
     "pelias-logger": "^1.2.1",
+    "pelias-whosonfirst": "^2.38.0",
     "remove-accents": "^0.4.0",
     "require-dir": "^1.0.0",
     "sorted-intersect": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lower-case": "^2.0.0",
     "morgan": "^1.9.0",
     "pelias-blacklist-stream": "^1.1.0",
+    "pelias-config": "^4.5.0",
     "pelias-logger": "^1.2.1",
     "pelias-whosonfirst": "^2.38.0",
     "remove-accents": "^0.4.0",


### PR DESCRIPTION
_This is a pull request into #157_

BREAKING_CHANGE: The path used to specify where Who's on First data is located should now _not_ end with `/data`. This will only affect people using Placeholder outside of the [Pelias Docker](https://github.com/pelias/docker) environment.


 This PR ensures that the bundle _and_ sqlite code in this repo can share a common base path set by `WOF_DIR`.

In the past, each required a different directory to work correctly because they depended on the whosonfirst layout directories of `data` and `sqlite` to be encoded in the `WOF_DIR` environment variable.

Now, the knowledge of which directory from the standard WOF layout to use is encoded in the extraction code. The bundle code looks in the `data` subdirectory, whereas the SQLite code looks in the `sqlite` directory.

The environment variable override in the `Dockerfile` have been updated accordingly.