### PR TITLE
Update data download locations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,29 +336,3 @@ $ docker pull pelias/placeholder
 We publish each commit and the latest of each branch to separate tags
 
 A list of all available tags to download can be found at https://hub.docker.com/r/pelias/placeholder/tags/
-
----
-
-### uploading a new build to s3
-
-this section is applicable to Pelias maintainers only and requires s3 credentials and the `aws` command to be installed and configured prior to running.
-
-other organizations may elect to change the bucket name in the config and utilize the same script.
-
-the script takes care of creating a date stamped archive and promoting the most recent build to the root of the bucket (with a public ACL).
-
-```bash
-$ AWS_PROFILE=nextzen ./cmd/s3_upload.sh
-
---- gzipping data files ---
---- uploading archive ---
-upload: data/store.sqlite3.gz to s3://pelias-data.nextzen.org/placeholder/archive/2017-09-29/store.sqlite3.gz
-upload: data/wof.extract.gz to s3://pelias-data.nextzen.org/placeholder/archive/2017-09-29/wof.extract.gz
---- list remote archive ---
-2017-09-29 14:52:33   46.6 MiB store.sqlite3.gz
-2017-09-29 14:53:08   53.8 MiB wof.extract.gz
-
-> would you like to promote this build to production (yes/no)?
-no
-you did not answer yes, the build was not promoted to production
-```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ $ npm install
 
 ### download the required database files
 
+Data hosting is provided by [Geocode Earth](https://geocode.earth). Other
+Pelias related downloads are available at https://geocode.earth/data.
+
 ```bash
 $ mkdir data
-$ curl -s https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz | gunzip > data/store.sqlite3;
+$ curl -s https://data.geocode.earth/placeholder/store.sqlite3.gz | gunzip > data/store.sqlite3;
 ```
 
 ### confirm the build was successful

--- a/README.md
+++ b/README.md
@@ -297,13 +297,6 @@ this process can take 30-60 minutes to run and consumes ~350MB of disk space, yo
 $ WOF_DIR=/data/whosonfirst-data/data npm run extract
 ```
 
-alternatively you can download the extract file from our s3 bucket:
-
-```bash
-$ mkdir data
-$ curl -s https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/wof.extract.gz | gunzip > data/wof.extract;
-```
-
 now you can rebuild the `data/store.json` file with the following command:
 
 this should take 2-3 minutes to run:


### PR DESCRIPTION
This PR provides some updates to the Placeholder data download instructions in the README.

Most notably, it removes any references to Nextzen-hosted data, which is no longer available.

As a replacement, the free downloads available from the [Geocode Earth data page](https://geocode.earth/data) are used. Pelias users could have already pieced together to use this download, but we might as well do it for them.

Closes https://github.com/pelias/placeholder/issues/168