### PR TITLE
bzip2 to lbzip2 migration to use all CPU cores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   fast_finish: true
 script: npm run travis
 env:
-  - BUCKET=https://storage.googleapis.com/pelias-data.geocode.earth/placeholder
+  - BUCKET=https://data.geocode.earth/placeholder/2019-01-28
 before_install:
   - npm i -g npm
 before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y build-essential python jq && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential python jq lbzip2 && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/placeholder

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y build-essential python jq lbzip2 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential python jq lbzip2 parallel && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/placeholder

--- a/cmd/download_extract.sh
+++ b/cmd/download_extract.sh
@@ -11,7 +11,11 @@ PLACETYPES=( 'neighbourhood' 'macrohood' 'borough' 'locality' 'localadmin' 'coun
 # download and extract fields from contents of tar
 function extract {
   curl -so "/tmp/wof-${1}-latest-bundle.tar.bz2" "https://whosonfirst.mapzen.com/bundles/wof-${1}-latest-bundle.tar.bz2"
-  tar --wildcards '*.geojson' -jx --to-command 'jq -cMf "${DIR}/jq.filter"' -f "/tmp/wof-${1}-latest-bundle.tar.bz2"
+  if hash lbzip2 2>/dev/null; then
+        tar --wildcards '*.geojson' -x --use-compress-program=lbzip2 --to-command 'jq -cMf "${DIR}/jq.filter"' -f "/tmp/wof-${1}-latest-bundle.tar.bz2"
+    else
+        tar --wildcards '*.geojson' -jx --to-command 'jq -cMf "${DIR}/jq.filter"' -f "/tmp/wof-${1}-latest-bundle.tar.bz2"
+    fi
   rc=$?; if [[ $rc != 0 ]]; then
     >&2 echo "/tmp/wof-${1}-latest-bundle.tar.bz2"
     >&2 echo "command exited with status: $rc"

--- a/cmd/download_extract.sh
+++ b/cmd/download_extract.sh
@@ -12,10 +12,10 @@ PLACETYPES=( 'neighbourhood' 'macrohood' 'borough' 'locality' 'localadmin' 'coun
 function extract {
   curl -so "/tmp/wof-${1}-latest-bundle.tar.bz2" "https://whosonfirst.mapzen.com/bundles/wof-${1}-latest-bundle.tar.bz2"
   if hash lbzip2 2>/dev/null; then
-        tar --wildcards '*.geojson' -x --use-compress-program=lbzip2 --to-command 'jq -cMf "${DIR}/jq.filter"' -f "/tmp/wof-${1}-latest-bundle.tar.bz2"
-    else
-        tar --wildcards '*.geojson' -jx --to-command 'jq -cMf "${DIR}/jq.filter"' -f "/tmp/wof-${1}-latest-bundle.tar.bz2"
-    fi
+    tar --wildcards '*.geojson' -x --use-compress-program=lbzip2 --to-command 'jq -cMf "${DIR}/jq.filter"' -f "/tmp/wof-${1}-latest-bundle.tar.bz2"
+  else
+    tar --wildcards '*.geojson' -jx --to-command 'jq -cMf "${DIR}/jq.filter"' -f "/tmp/wof-${1}-latest-bundle.tar.bz2"
+  fi
   rc=$?; if [[ $rc != 0 ]]; then
     >&2 echo "/tmp/wof-${1}-latest-bundle.tar.bz2"
     >&2 echo "command exited with status: $rc"


### PR DESCRIPTION
**Summary of changes:** 
1. If `lbzip2` installed on system we use it. If not, using legacy `bzip2`.
2. Updated `Dockerfile` to install `lbzip2` and `parallel`

Related to [discussion about issue 480](https://github.com/pelias/whosonfirst/issues/480) in `pelias/whosonfirst`

Related also to #142 #143