### PR TITLE
fix(CI): use Geocode Earth CDN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   fast_finish: true
 script: npm run travis
 env:
-  - BUCKET=https://storage.googleapis.com/pelias-data.geocode.earth/placeholder
+  - BUCKET=https://data.geocode.earth/placeholder/2019-01-28
 before_install:
   - npm i -g npm
 before_script:


### PR DESCRIPTION
The Travis-CI job is failing because I moved the data and deleted the bucket a few days ago.
This PR updates the env var to point to the Geocode Earth CDN.
