### PR TITLE
Remove docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '2'
-services:
-  placeholder:
-    image: mapzen/pelias-placeholder
-    build: .
-    restart: always
-    environment: [ "PORT=3000" ]
-    ports: [ "6100:3000" ]


### PR DESCRIPTION
This file is from 2017 and references a Mapzen Docker image. I don't think we ever really used this.