### PR TITLE
use journal_mode=MEMORY for performance

### DIFF
--- a/cmd/load.js
+++ b/cmd/load.js
@@ -1,9 +1,8 @@
-
-var split = require('split2'),
-    through = require('through2'),
-    parser = require('../lib/jsonParseStream'),
-    Placeholder = require('../Placeholder'),
-    ph = new Placeholder();
+const split = require('split2');
+const through = require('through2');
+const parser = require('../lib/jsonParseStream');
+const Placeholder = require('../Placeholder');
+const ph = new Placeholder();
 
 // run import pipeline
 console.error('import...');

--- a/lib/Database.js
+++ b/lib/Database.js
@@ -44,7 +44,7 @@ Database.prototype.configure = function(){
   this.db.pragma('page_size=4096'); // (default: 1024)
   this.db.pragma('cache_size=-2000'); // (default: -2000, 2GB)
   this.db.pragma('synchronous=OFF');
-  this.db.pragma('journal_mode=OFF');
+  this.db.pragma('journal_mode=MEMORY');
   this.db.pragma('temp_store=MEMORY');
 };
 

--- a/lib/DocStore.js
+++ b/lib/DocStore.js
@@ -8,6 +8,7 @@ util.inherits( DocStore, Database );
 
 DocStore.prototype.reset = function(){
   this.db.exec('DROP TABLE IF EXISTS docs');
+  this.db.exec('DROP TABLE IF EXISTS rtree');
   this.db.exec('CREATE TABLE docs( id INTEGER PRIMARY KEY, json TEXT )');
 
   // create rtree table

--- a/test/lib/Database.js
+++ b/test/lib/Database.js
@@ -1,5 +1,5 @@
-
-var Database = require('../../lib/Database');
+const _ = require('lodash');
+const Database = require('../../lib/Database');
 
 module.exports.constructor = function(test, common) {
   test('constructor', function(t) {
@@ -87,12 +87,12 @@ module.exports.prepare = function(test, common) {
   test('prepare', function(t) {
     var db = new Database();
     db.open('/tmp/db', { test: true });
-    
+
     t.equal(typeof db.stmt, 'undefined');
-    
+
     const sql = 'SELECT * FROM sqlite_master';
     db.prepare(sql);
-    
+
     t.true(typeof db.stmt, 'object');
     t.true(db.stmt.hasOwnProperty(sql));
     t.deepEqual(db.stmt[sql], {
@@ -100,7 +100,7 @@ module.exports.prepare = function(test, common) {
       source: 'SELECT * FROM sqlite_master',
       database: db.db
     });
-    
+
     t.end();
   });
 };
@@ -111,19 +111,19 @@ module.exports.configure = function(test, common) {
     db.open('/tmp/db', { test: true });
 
     // configure
-    const pragma_checks = [
-      { foreign_keys: 0 },
-      { page_size: 4096 },
-      { cache_size: -2000 },
-      { synchronous: 0 },
-      // { journal_mode: 0 },
-      { temp_store: 2 }
-    ];
+    const pragma_checks = {
+      foreign_keys: 0,
+      page_size: 4096,
+      cache_size: -2000,
+      synchronous: 0,
+      // journal_mode: 'memory',
+      temp_store: 2
+    };
 
-    t.plan( pragma_checks.length );
-    pragma_checks.forEach( pragma => {
-      var sql = 'PRAGMA ' + Object.keys(pragma)[0] + ';';
-      t.deepEqual( db.db.prepare(sql).get(), pragma );
+    t.plan(_.size(pragma_checks));
+    _.forEach(pragma_checks, (value, key) => {
+      const stmt = db.db.prepare(`PRAGMA ${key};`);
+      t.deepEqual(stmt.get(), { [key]: value });
     });
   });
 };


### PR DESCRIPTION
When using `pelias/docker` to create a placeholder database today I found that it was very sloooow.

I watched the `PLACEHOLDER_DATA` dir in another terminal and noticed that the journal file was being created despite us setting `journal_mode=OFF`.

I'm not 100% sure why this is happening 🤷 but it's fixed by setting `journal_mode=MEMORY` instead 🎉 

I noticed a 14x speed improvement as a result of using this configuration.

```bash
# before
node cmd/load.js  5.97s user 24.37s system 93% cpu 32.439 total

# after
node cmd/load.js  3.77s user 1.69s system 108% cpu 5.038 total
```