### PR TITLE
upgrade data to latest from WOF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - 12
 script: npm run travis
 env:
-  - BUCKET=https://data.geocode.earth/placeholder/2019-01-28
+  - BUCKET=https://data.geocode.earth/placeholder/2020-05-05
 before_install:
   - npm i -g npm
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - 12
 script: npm run travis
 env:
-  - BUCKET=https://data.geocode.earth/placeholder/2020-05-05
+  - BUCKET=https://data.geocode.earth/placeholder
 before_install:
   - npm i -g npm
 before_script:

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -78,7 +78,7 @@
 890413117 Noumea, New Caledonia
 890440179 Kingston, Norfolk Island
 101751893 Amsterdam, Netherlands
-101751917 Oslo, Norway
+1495123997 Oslo, Norway
 85675677 Yaren, Nauru
 1141909453 Alofi, Niue
 890445081 Panama City, Panama

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -84,7 +84,7 @@
 890445081 Panama City, Panama
 890435983 Saint-Pierre, Saint Pierre and Miquelon
 85676471 Melekeok, Palau
-890441607 Doha, Qatar
+421190363 Doha, Qatar
 102003033 Moscow, Russia
 890444217 Honiara, Solomon Islands
 421202159 Victoria, Seychelles

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -26,7 +26,7 @@
 102016915 Santiago, Chile
 85670331 Praia, Cape Verde
 421187435 Willemstad, Curacao
-101748799 Berlin, Germany
+101909779 Berlin, Germany
 101749159 Copenhagen, Denmark
 890442101 Roseau, Dominica
 101748153 Tallinn, Estonia

--- a/test/functional.js
+++ b/test/functional.js
@@ -11,7 +11,7 @@ module.exports.functional = function(test, util) {
 
   assert('Kelburn Wellington New Zealand', [85772991]);
   assert('North Sydney', [85771181, 85784821, 101931469, 102048877, 404225393, 1310698409]);
-  assert('Sydney New South Wales Australia', [101932003, 102049151, 404226357]);
+  assert('Sydney New South Wales Australia', [101932003, 102049151, 404226357, 1376953385, 1377004395]);
   assert('ケープタウン 南アフリカ', [101928027]);
   assert('경기도 광명시', [890472589]);
   assert('서울 마포구', [890473201]);

--- a/test/functional.js
+++ b/test/functional.js
@@ -13,9 +13,13 @@ module.exports.functional = function(test, util) {
   assert('North Sydney', [85784821, 101931469, 102048877, 404225393, 1310698409]);
   assert('Sydney New South Wales Australia', [101932003, 102049151, 404226357, 1376953385, 1377004395]);
   assert('ケープタウン 南アフリカ', [101928027]);
-  assert('경기도 광명시', [890472589]);
+
+  // possible duplicates
+  // see: https://github.com/whosonfirst-data/whosonfirst-data/issues/1841
+  assert('경기도 광명시', [102026551, 890472589]);
+  assert('부산광역시 부산진구', [890475779, 890476045]);
+
   assert('서울 마포구', [890473201]);
-  assert('부산광역시 부산진구', [890475779]);
   assert('전라북도 전주시 완산구', [102026471]);
 
   assert('london on', [ 101735809 ]);

--- a/test/functional.js
+++ b/test/functional.js
@@ -10,7 +10,7 @@ module.exports.functional = function(test, util) {
   var assert = runner.bind(null, test, ph);
 
   assert('Kelburn Wellington New Zealand', [85772991]);
-  assert('North Sydney', [85771181, 85784821, 101931469, 102048877, 404225393, 1310698409]);
+  assert('North Sydney', [85784821, 101931469, 102048877, 404225393, 1310698409]);
   assert('Sydney New South Wales Australia', [101932003, 102049151, 404226357, 1376953385, 1377004395]);
   assert('ケープタウン 南アフリカ', [101928027]);
   assert('경기도 광명시', [890472589]);

--- a/test/functional.js
+++ b/test/functional.js
@@ -22,7 +22,7 @@ module.exports.functional = function(test, util) {
   assert('paris, tx', [ 101725293 ]);
 
   assert('123 apple bay ave neutral bay north sydney new south wales au',
-    [ 85774601, 101931387, 404225267 ]
+    [ 101931387, 404225267 ]
   );
 
   assert('30 w 26th st ny nyc 10117 ny usa', [ 85977539 ]);

--- a/test/prototype/query_integration.js
+++ b/test/prototype/query_integration.js
@@ -10,7 +10,7 @@ module.exports.query = function(test, util) {
   var assert = runner.bind(null, test, ph);
 
   assert([['kelburn', 'wellington', 'new zealand']], [85772991]);
-  assert([['north sydney']], [85771181, 85784821, 101931469, 102048877, 404225393, 1310698409]);
+  assert([['north sydney']], [85784821, 101931469, 102048877, 404225393, 1310698409]);
   assert([['sydney', 'new south wales', 'australia']], [101932003, 102049151, 404226357, 1376953385, 1377004395]);
   assert([['ケープタウン', '南アフリカ']], [101928027]);
 };

--- a/test/prototype/query_integration.js
+++ b/test/prototype/query_integration.js
@@ -11,7 +11,7 @@ module.exports.query = function(test, util) {
 
   assert([['kelburn', 'wellington', 'new zealand']], [85772991]);
   assert([['north sydney']], [85771181, 85784821, 101931469, 102048877, 404225393, 1310698409]);
-  assert([['sydney', 'new south wales', 'australia']], [101932003, 102049151, 404226357]);
+  assert([['sydney', 'new south wales', 'australia']], [101932003, 102049151, 404226357, 1376953385, 1377004395]);
   assert([['ケープタウン', '南アフリカ']], [101928027]);
 };
 


### PR DESCRIPTION
this PR upgrades the data to use the latest version available from whosonfirst.
prior to this change the data was ~1.5 years old, so expect some changes.

- update placeholder data download
- update tests
- opened any relevant issues with the WOF team

linked:
- https://github.com/whosonfirst-data/whosonfirst-data/issues/1841
- https://github.com/whosonfirst-data/whosonfirst-data/issues/1842
- https://github.com/whosonfirst-data/whosonfirst-data/issues/1843