### PR TITLE
more verbosity for debugging Malformed JSON errors

### DIFF
--- a/lib/DocStore.js
+++ b/lib/DocStore.js
@@ -69,6 +69,7 @@ DocStore.prototype.set = function( id, doc, cb ){
   } catch ( err ){
     console.error( err );
     console.error( stmt.source );
+    console.error( id, doc );
     return cb( err );
   }
 };


### PR DESCRIPTION
In order to further investigate and solve https://github.com/pelias/placeholder/issues/183 I have added a third log line which should print the ID and Document causing the error.