### PR TITLE
add "township" as a synonym for "charter township

### DIFF
--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -82,13 +82,14 @@ function normalize( input ){
   }
 
   // synonymous representations of official designations
-  if( input.match(/county|city/i) ){
+  if (input.match(/county|city|township/i) ){
     synonyms = synonyms.concat(
-      synonyms.map( function( synonym ){
+      synonyms.map(synonym => {
         return synonym
           .replace(/^county\s(of\s)?(.*)$/gi, '$2')
           .replace(/^(.*)\scounty$/gi, '$1')
-          .replace(/^city\sof(?!\s?the)\s?(.*)$/gi, '$1');
+          .replace(/^city\sof(?!\s?the)\s?(.*)$/gi, '$1')
+          .replace(/^(.*\s)charter\s(township)$/gi, '$1$2');
       })
     );
   }

--- a/test/lib/analysis.js
+++ b/test/lib/analysis.js
@@ -61,6 +61,10 @@ module.exports.normalize = function(test, common) {
   assert( 'City of the Sun', [ 'city of the sun' ] );
   assert( 'City of Sun', [ 'city of sun', 'sun' ] );
 
+  // https://en.wikipedia.org/wiki/Charter_township
+  assert( 'Word Charter Township', [ 'word charter township', 'word township' ] );
+  assert( 'Two Words Charter Township', [ 'two words charter township', 'two words township' ] );
+
   // remove 'disambiguation' tokens from name suffix
   // see: https://github.com/whosonfirst-data/whosonfirst-data/issues/885
   assert( 'St Kilda (Vic.)', [ 'st kilda' ] );


### PR DESCRIPTION
this PR adds to our list of "synonymous representations of official designations".
it ensures that 'Foo Charter Township' is considered synonymous with 'Foo Township', even if an alt name is not available in the data.

https://en.wikipedia.org/wiki/Charter_township