### PR TITLE
chore: remove unused dependency on istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "repl": "node cmd/repl.js",
     "cli": "node cmd/cli.js",
     "lint": "jshint .",
-    "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "validate": "npm ls",
     "travis": "npm run all"
   },
@@ -50,7 +49,6 @@
     "through2": "^3.0.0"
   },
   "devDependencies": {
-    "istanbul": "^0.4.2",
     "jshint": "^2.5.6",
     "precommit-hook": "^3.0.0",
     "tap-spec": "^5.0.0",


### PR DESCRIPTION
Nothing calls `npm run coverage`, and even if it did, `test/unit/run.js` does not exist in this repository. In addition, [`istanbul` is no longer maintained](https://www.npmjs.com/package/istanbul). Seems like the best thing to do is remove this broken code from the repo.

If we want to get code coverage measurements working on this repo in the future, great! But that can be done independently of this work.