### PR TITLE
Upgrade pelias-whosonfirst to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pelias-blacklist-stream": "^1.1.0",
     "pelias-config": "^4.5.0",
     "pelias-logger": "^1.2.1",
-    "pelias-whosonfirst": "^4.0.0",
+    "pelias-whosonfirst": "^5.0.0",
     "remove-accents": "^0.4.0",
     "require-dir": "^1.0.0",
     "sorted-intersect": "^0.1.4",


### PR DESCRIPTION
We recently bumped the whosonfirst repository to 5.0.0 with a breaking change not relevant to Placeholder.

However, since then we've updated some functionality and, notably, upgraded `better-sqlite` to version 7.

This bump will ensure we track the latest version of that project.