### PR TITLE
Upgrade to better-sqlite 7

### DIFF
--- a/lib/Database.js
+++ b/lib/Database.js
@@ -7,11 +7,11 @@ function Database(){}
 Database.prototype.open = function( path, options ){
 
   // set up a safe environment for running tests.
-  // note: usually in-memory databases using the same
-  // path would share the same database reference.
+  // note: each instance of an in-memory database that's created is unique
+  // this means that we can ignore the 'path' parameter and use ':memory:'
+  // https://www.sqlite.org/inmemorydb.html
   if( options && true === options.test ){
-    options.memory = true;
-    path += Math.random().toString(36).substr(2);
+    path = ':memory:';
   }
 
   // open connection

--- a/lib/DocStore.js
+++ b/lib/DocStore.js
@@ -49,12 +49,12 @@ DocStore.prototype.checkSchema = function(){
   ]);
   Database.assertSchema(this.db, 'rtree', [
     { cid: 0, name: 'id', type: 'INT', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 1, name: 'minX', type: 'NUM', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 2, name: 'maxX', type: 'NUM', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 3, name: 'minY', type: 'NUM', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 4, name: 'maxY', type: 'NUM', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 5, name: 'minZ', type: 'NUM', notnull: 0, dflt_value: null, pk: 0 },
-    { cid: 6, name: 'maxZ', type: 'NUM', notnull: 0, dflt_value: null, pk: 0 }
+    { cid: 1, name: 'minX', type: 'REAL', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 2, name: 'maxX', type: 'REAL', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 3, name: 'minY', type: 'REAL', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 4, name: 'maxY', type: 'REAL', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 5, name: 'minZ', type: 'REAL', notnull: 0, dflt_value: null, pk: 0 },
+    { cid: 6, name: 'maxZ', type: 'REAL', notnull: 0, dflt_value: null, pk: 0 }
   ]);
 };
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/pelias/placeholder#readme",
   "dependencies": {
     "async": "^3.0.1",
-    "better-sqlite3": "^6.0.1",
+    "better-sqlite3": "^7.1.5",
     "express": "^4.15.2",
     "lodash": "^4.17.4",
     "lower-case": "^2.0.0",
@@ -42,7 +42,7 @@
     "pelias-blacklist-stream": "^1.1.0",
     "pelias-config": "^4.5.0",
     "pelias-logger": "^1.2.1",
-    "pelias-whosonfirst": "^4.0.0",
+    "pelias-whosonfirst": "^5.0.0",
     "remove-accents": "^0.4.0",
     "require-dir": "^1.0.0",
     "sorted-intersect": "^0.1.4",


### PR DESCRIPTION
better-sqlite 7 is a [pretty big release](https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.0.0), with some changes including dropping support for really old Node.js versions, dropping the `Integer` module dependency and instead using native BigInts, etc.

Using this version is also required to support the newest Node.js versions as well as ARM CPUs like the Apple M1.

To upgrade, we have to bump both the direct dependency on `better-sqlite` and our dependency on `pelias-whosonfirst`, which I guess we forgot to upgrade a while back.