### PR TITLE
data-update: update tests to reflect latest ID changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ placeholder > tokenize sydney new south wales
  [ [ 'sydney', 'new south wales' ] ]
 
 placeholder > token kelburn
- [ 85772991 ]
+ [ 1729339019 ]
 
-placeholder > id 85772991
+placeholder > id 1729339019
  { name: 'Kelburn',
    placetype: 'neighbourhood',
    lineage:
@@ -246,7 +246,7 @@ placeholder > id 85772991
       country_id: 85633345,
       county_id: 102079339,
       locality_id: 101915529,
-      neighbourhood_id: 85772991,
+      neighbourhood_id: 1729339019,
       region_id: 85687233 },
    names: { eng: [ 'Kelburn' ] } }
 ```

--- a/test/cases/capitalCities.txt
+++ b/test/cases/capitalCities.txt
@@ -9,7 +9,7 @@
 85667871 Mariehamn, Aland Islands
 890518775 Sarajevo, Bosnia and Herzegovina
 890452811 Bridgetown, Barbados
-890440103 Manama, Bahrain
+421190647 Manama, Bahrain
 421204487 Bujumbura, Burundi
 421168997 Porto-Novo, Benin
 890442097 Hamilton, Bermuda

--- a/test/cases/citySearch.txt
+++ b/test/cases/citySearch.txt
@@ -331,7 +331,7 @@
 85923645 Diamond Bar
 85632319 Djibouti
 101752861 Dnipropetrovsk
-890441607 Doha
+421190363 Doha
 85904051 Dombivli
 102027633 Dongguan
 101751841 Dordrecht
@@ -663,7 +663,7 @@
 85923517 Los Angeles
 85929677 Loveland
 85950327 Lowell
-101914319 Lower Hutt
+1729238533 Lower Hutt
 101750443 Lowestoft
 85667669 Luanda
 101725261 Lubbock
@@ -692,7 +692,7 @@
 85950349 Malden
 85675495 Managua
 102050371 Manaus
-101913963 Manchester, England
+101750525 Manchester, England
 85975081 Manchester, NH
 85674559 Mandalay
 421205771 Manhattan
@@ -1112,7 +1112,7 @@
 102018911 Surabaya
 85917473 Surprise
 102027777 Suzhou
-85771099 Sydney
+101932003 Sydney
 85977785 Syracuse
 101752779 Szczecin
 101751681 Szeged

--- a/test/functional.js
+++ b/test/functional.js
@@ -9,7 +9,7 @@ module.exports.functional = function(test, util) {
 
   var assert = runner.bind(null, test, ph);
 
-  assert('Kelburn Wellington New Zealand', [85772991]);
+  assert('Kelburn Wellington New Zealand', [1729339019]);
   assert('North Sydney', [85784821, 101931469, 102048877, 404225393, 1310698409]);
   assert('Sydney New South Wales Australia', [101932003, 102049151, 404226357, 1376953385, 1377004395]);
   assert('ケープタウン 南アフリカ', [101928027]);
@@ -32,7 +32,7 @@ module.exports.functional = function(test, util) {
   assert('30 w 26th st ny nyc 10117 ny usa', [ 85977539 ]);
 
   // should not include county: 102081377, or localadmin: 404482867
-  assert('lancaster lancaster pa', [ 101718643, 404487183, 404487185 ]);
+  assert('lancaster lancaster pa', [ 101718643, 404487183, 404487185, 1729458067, 1729466275 ]);
 
   // assertions from pelias acceptance-test suite
   assert('灣仔, 香港', [85671779, 1243098523]);

--- a/test/functional_autocomplete.js
+++ b/test/functional_autocomplete.js
@@ -9,15 +9,15 @@ module.exports.functional = function(test, util) {
 
   var assert = runner.bind(null, test, ph);
 
-  assert('Kelbur\x26', [85772991, 1326645067]);
-  assert('Kelburn\x26', [85772991, 1326645067]);
-  assert('Kelburn W\x26', [85772991]);
-  assert('Kelburn Well\x26', [85772991]);
-  assert('Kelburn Wellington\x26', [85772991]);
-  assert('Kelburn Wellington New\x26', [85772991]);
-  assert('Kelburn Wellington New Z\x26', [85772991]);
-  assert('Kelburn Wellington New Zeal\x26', [85772991]);
-  assert('Kelburn Wellington New Zealand\x26', [85772991]);
+  assert('Kelbur\x26', [1326645067, 1729339019]);
+  assert('Kelburn\x26', [1326645067, 1729339019]);
+  assert('Kelburn W\x26', [1729339019]);
+  assert('Kelburn Well\x26', [1729339019]);
+  assert('Kelburn Wellington\x26', [1729339019]);
+  assert('Kelburn Wellington New\x26', [1729339019]);
+  assert('Kelburn Wellington New Z\x26', [1729339019]);
+  assert('Kelburn Wellington New Zeal\x26', [1729339019]);
+  assert('Kelburn Wellington New Zealand\x26', [1729339019]);
 };
 
 // convenience function for writing quick 'n easy test cases

--- a/test/prototype/query_integration.js
+++ b/test/prototype/query_integration.js
@@ -9,7 +9,7 @@ module.exports.query = function(test, util) {
 
   var assert = runner.bind(null, test, ph);
 
-  assert([['kelburn', 'wellington', 'new zealand']], [85772991]);
+  assert([['kelburn', 'wellington', 'new zealand']], [1729339019]);
   assert([['north sydney']], [85784821, 101931469, 102048877, 404225393, 1310698409]);
   assert([['sydney', 'new south wales', 'australia']], [101932003, 102049151, 404226357, 1376953385, 1377004395]);
   assert([['ケープタウン', '南アフリカ']], [101928027]);


### PR DESCRIPTION
It's been a while since the publicly hosted database at `https://data.geocode.earth/placeholder/store.sqlite3.gz` has been updated.

Prior to today the version at that URL was cut `2020-08-01` and I'm going to replace it with a copy from `2021-08-01`.

Naturally some changes were made which resulted in test failures, this PR updates the IDs of superseded records.