### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run unit tests
         run: |
           npm install
-          npm run travis
+          npm run ci
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,7 @@ jobs:
         os:
           - ubuntu-20.04
         node-version:
+          - 12.x
           - 14.x
           - 16.x
     steps:
@@ -16,17 +17,6 @@ jobs:
         uses: actions/setup-node@v2-beta
         with:
           node-version: '${{ matrix.node-version }}'
-      - name: Download database
-        shell: bash
-        env:
-          BUCKET: https://data.geocode.earth/placeholder
-        run: |
-          export AGENT="github/${GITHUB_ACTOR}"
-          export REFERER="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
-          mkdir data
-          curl -A ${AGENT} -e ${REFERER} -sfo data/store.sqlite3.gz ${BUCKET}/archive/$(date +%Y-%m-%d)/store.sqlite3.gz || true
-          [ -e data/store.sqlite3.gz ] || curl -A ${AGENT} -e ${REFERER} -so data/store.sqlite3.gz ${BUCKET}/store.sqlite3.gz
-          gunzip data/store.sqlite3.gz
       - name: Run unit tests
         run: |
           npm install
@@ -34,13 +24,13 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install node.js 12.x
+      - name: Install Node.js
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
@@ -57,10 +47,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Dump needs context
-        env:
-          NEEDS_CONTEXT: ${{ toJSON(needs) }}
-        run: echo "$NEEDS_CONTEXT"
       - name: Build Docker images
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/cmd/ci.sh
+++ b/cmd/ci.sh
@@ -1,0 +1,13 @@
+# Download Placeholder data for tests
+BUCKET=https://data.geocode.earth/placeholder
+
+export AGENT="github/${GITHUB_ACTOR}"
+export REFERER="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+mkdir data
+curl -A ${AGENT} -e ${REFERER} -sfo data/store.sqlite3.gz ${BUCKET}/archive/$(date +%Y-%m-%d)/store.sqlite3.gz || true
+[ -e data/store.sqlite3.gz ] || curl -A ${AGENT} -e ${REFERER} -so data/store.sqlite3.gz ${BUCKET}/store.sqlite3.gz
+gunzip data/store.sqlite3.gz
+
+npm install
+
+npm run all

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cli": "node cmd/cli.js",
     "lint": "jshint .",
     "validate": "npm ls",
-    "travis": "npm run all"
+    "travis": "./cmd/ci.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cli": "node cmd/cli.js",
     "lint": "jshint .",
     "validate": "npm ls",
-    "travis": "./cmd/ci.sh"
+    "ci": "./cmd/ci.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This copies the Github Actions workflow from the Pelias API project.

It brings in a few notable changes:
- Run all tests against Node.js 12, 14, and 16
- Remove MacOS build jobs (they're 10x the cost, which could hurt anyone running these on private forks)
- Update jobs to run on Ubuntu 20 (Ubuntu 16 is deprecated: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/)
- Run docker build _after_ any NPM publish, so that versioned docker images can be built

For this repository I also added a new `ci.sh` script that includes the instructions for downloading data needed to run the tests. By including that in the `npm run ci` command, we can keep the GitHub Actions workflow file exactly the same as other repositories, while still including that Placeholder-specific setup code.