### PR TITLE
performance: use autocomplete query in place of string matching

### DIFF
--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -163,10 +163,10 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
     );
   } else {
     this._queryAll(
-      this.prepare( query.match_subject_object_geom_intersects ),
+      this.prepare( query.match_subject_object_geom_intersects_autocomplete ),
       {
         subject: subject,
-        object: object,
+        object: `"${object}"`,
         threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },


### PR DESCRIPTION
this PR is a solution for https://github.com/pelias/placeholder/issues/209

There are two forms of token matching within this codebase:
1) [traditional `x = y` string matching using a SQLite index over the `tokens` table](https://github.com/pelias/placeholder/blob/master/query/match_subject_object_geom_intersects.sql)
2) [using the `MATCH` keyword to check for equality of tokens using the FTS5 extension of SQLite on the `fulltext` table (which is a shadow of `tokens` with a different internal format)](https://github.com/pelias/placeholder/blob/master/query/match_subject_object_geom_intersects_autocomplete.sql)

These two methods have differing performance characteristics, it's preferable to use the `MATCH` method for prefix matching as it has significantly better performance than using `LIKE x%` on the traditional index.

It turns out, despite the additional `JOIN`, that the `MATCH` syntax is actually more performant than `=` on full token matching too, at least in this case.