### PR TITLE
Remove unnecessary compiler toolchain dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y build-essential python jq lbzip2 parallel && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y jq lbzip2 parallel && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/placeholder


### PR DESCRIPTION
After better-sqlite3 added support for [pre-compiled binaries](https://github.com/JoshuaWise/better-sqlite3/releases/tag/v6.0.0), we no longer need to install a compiler toolchain to run npm install in our Docker images.

pelias/docker-baseimage#23 removes the compiler toolchain from our Pelias baseimages. In order for the toolchain to be removed from the Placeholder image in particular, we also need to remove those dependencies here.

Similar to the whosonfirst repository in https://github.com/pelias/whosonfirst/pull/532, this change by itself is effectively a no-op. After the baseimage removes the compiler toolchain, the size of the Placeholder docker image goes from 495MB to 266MB, an impressive 229MB savings!