### PR TITLE
ci: remove "archive" path prefix from fixture download URL

### DIFF
--- a/cmd/ci.sh
+++ b/cmd/ci.sh
@@ -4,7 +4,7 @@ BUCKET=https://data.geocode.earth/placeholder
 export AGENT="github/${GITHUB_ACTOR}"
 export REFERER="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 mkdir data
-curl -A ${AGENT} -e ${REFERER} -sfo data/store.sqlite3.gz ${BUCKET}/archive/$(date +%Y-%m-%d)/store.sqlite3.gz || true
+curl -A ${AGENT} -e ${REFERER} -sfo data/store.sqlite3.gz ${BUCKET}/$(date +%Y-%m-%d)/store.sqlite3.gz || true
 [ -e data/store.sqlite3.gz ] || curl -A ${AGENT} -e ${REFERER} -so data/store.sqlite3.gz ${BUCKET}/store.sqlite3.gz
 gunzip data/store.sqlite3.gz
 


### PR DESCRIPTION
as mentioned in https://github.com/pelias/placeholder/pull/207#issuecomment-960781865 and extracted from that PR.

the CI script looks for a file with the prefix `archive` although that directory doesn't exist on either BunnyCDN or S3, I'm not sure what the history is but it seems to have not worked for some time now.

the purpose of this line of code is to allow the CI to pass *before* publishing the data for wider release, there's a catch22 situation where the code can't get merged because the data needs to be updated and the new data can't be released until the CI passes.