### PR TITLE
fix incorrect matching of Thai characters in FTS5

### DIFF
--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -152,10 +152,10 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
     if( '' === object.trim() ){ return cb( null, [] ); }
 
     this._queryAll(
-      this.prepare( query.match_subject_object_geom_intersects ),
+      this.prepare( query.match_subject_object_geom_intersects_autocomplete ),
       {
-        subject: `"${subject}"`,
-        object: `"${object}" OR "${object}"*`,
+        subject,
+        object,
         threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },
@@ -165,8 +165,8 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
     this._queryAll(
       this.prepare( query.match_subject_object_geom_intersects ),
       {
-        subject: `"${subject}"`,
-        object: `"${object}"`,
+        subject,
+        object,
         threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },

--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -156,6 +156,8 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
       {
         subject,
         object,
+        subject_quoted: `"${subject}"`,
+        object_quoted: `"${object}"`,
         threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },
@@ -167,6 +169,8 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
       {
         subject,
         object,
+        subject_quoted: `"${subject}"`,
+        object_quoted: `"${object}"`,
         threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },

--- a/query/match_subject_object_geom_intersects.sql
+++ b/query/match_subject_object_geom_intersects.sql
@@ -11,7 +11,7 @@ FROM fulltext f1
         (r1.minY - $threshold) < r2.maxY AND
         (r1.maxY + $threshold) > r2.minY
       )
-        JOIN fulltext AS f2 ON f2.fulltext MATCH $object
+        JOIN fulltext AS f2 ON f2.fulltext MATCH $object_quoted
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
             AND r2.id = t2.id
@@ -22,7 +22,7 @@ FROM fulltext f1
               t2.lang IN ('eng', 'und')
             )
           )
-WHERE f1.fulltext MATCH $subject
+WHERE f1.fulltext MATCH $subject_quoted
 AND t1.token = $subject
 GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC

--- a/query/match_subject_object_geom_intersects.sql
+++ b/query/match_subject_object_geom_intersects.sql
@@ -14,6 +14,7 @@ FROM fulltext f1
         JOIN fulltext AS f2 ON f2.fulltext MATCH $object
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
+            AND t2.token = TRIM($object, '"')
             AND r2.id = t2.id
             AND (
               t1.lang = t2.lang OR
@@ -22,6 +23,7 @@ FROM fulltext f1
             )
           )
 WHERE f1.fulltext MATCH $subject
+AND t1.token = TRIM($subject, '"')
 GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC
 LIMIT $limit

--- a/query/match_subject_object_geom_intersects_autocomplete.sql
+++ b/query/match_subject_object_geom_intersects_autocomplete.sql
@@ -11,11 +11,11 @@ FROM fulltext f1
         (r1.minY - $threshold) < r2.maxY AND
         (r1.maxY + $threshold) > r2.minY
       )
-        JOIN fulltext AS f2 ON f2.fulltext MATCH $object
+        JOIN fulltext AS f2 ON f2.fulltext MATCH $object OR $object*
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
             AND r2.id = t2.id
-            AND t2.token = $object
+            AND (t2.token = $object OR t2.token LIKE ($object || '%'))
             AND (
               t1.lang = t2.lang OR
               t1.lang IN ('eng', 'und') OR

--- a/query/match_subject_object_geom_intersects_autocomplete.sql
+++ b/query/match_subject_object_geom_intersects_autocomplete.sql
@@ -11,7 +11,7 @@ FROM fulltext f1
         (r1.minY - $threshold) < r2.maxY AND
         (r1.maxY + $threshold) > r2.minY
       )
-        JOIN fulltext AS f2 ON f2.fulltext MATCH $object OR $object*
+        JOIN fulltext AS f2 ON f2.fulltext MATCH $object_quoted OR $object_quoted*
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
             AND r2.id = t2.id
@@ -22,7 +22,7 @@ FROM fulltext f1
               t2.lang IN ('eng', 'und')
             )
           )
-WHERE f1.fulltext MATCH $subject
+WHERE f1.fulltext MATCH $subject_quoted
 AND t1.token = $subject
 GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC


### PR DESCRIPTION
There appears to be a bug in the [FTS5](https://www.sqlite.org/fts5.html) analysis module regarding Thai characters.

It *should* be that the `tokens.token` column and the `fulltext.fulltext` column contain the same token and therefore have the same matching functionality, the FTS5 table is significantly faster (even when including the `JOIN`) so we generally use that instead of the index on `tokens`.

However it turns out, for Thai at least, that this isn't true:

```bash
SELECT COUNT(*)
FROM tokens t1
WHERE t1.token = 'จ';
0

SELECT COUNT(*)
FROM fulltext f1
JOIN tokens t1 ON (f1.rowid = t1.rowid)
WHERE f1.fulltext MATCH '"จ"';
2904
```

It seems that the `FTS5` module erroneously performs prefix matching of this character despite the query not containing a star and therefore not requesting a prefix search.

This PR is a simple workaround for this, and any other cases where the two columns don't match, we simple check both.