### PR TITLE
introduce fts_term() function for preparing tokens for FTS5 token matching

### DIFF
--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -148,7 +148,7 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
   if( 0 > RTREE_THRESHOLD ){ return cb( null, [] ); }
 
   if( isPartialToken ){
-    object = object.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '');
+    object = object.replace(REMOVE_PARTIAL_TOKEN_REGEX, '');
     if( '' === object.trim() ){ return cb( null, [] ); }
 
     this._queryAll(
@@ -156,8 +156,8 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
       {
         subject,
         object,
-        subject_quoted: `"${subject}"`,
-        object_quoted: `"${object}"`,
+        subject_fts: fts_term(subject),
+        object_fts: fts_term(object),
         threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },
@@ -169,8 +169,8 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
       {
         subject,
         object,
-        subject_quoted: `"${subject}"`,
-        object_quoted: `"${object}"`,
+        subject_fts: fts_term(subject),
+        object_fts: fts_term(object),
         threshold: RTREE_THRESHOLD,
         limit: MAX_RESULTS
       },
@@ -178,3 +178,11 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
     );
   }
 };
+
+// fts_term() converts a regular term (of one or more tokens)
+// into a format which can be used by the FTS5 table.
+//  1. terms should be enclosed in double-quotes
+//  2. spaces should be replaced with underscores (as per the analyzer)
+function fts_term(term) {
+  return `"${term.replace(/ /g, '_')}"`;
+}

--- a/query/match_subject_object_geom_intersects.sql
+++ b/query/match_subject_object_geom_intersects.sql
@@ -4,7 +4,7 @@ SELECT
 FROM fulltext f1
   JOIN tokens t1 ON (
     f1.rowid = t1.rowid
-    AND f1.fulltext MATCH $subject_quoted
+    AND f1.fulltext MATCH $subject_fts
     AND LIKELY(t1.token = $subject)
   )
     JOIN rtree AS r1 ON t1.id = r1.id
@@ -15,7 +15,7 @@ FROM fulltext f1
         (r1.minY - $threshold) < r2.maxY AND
         (r1.maxY + $threshold) > r2.minY
       )
-        JOIN fulltext AS f2 ON f2.fulltext MATCH $object_quoted
+        JOIN fulltext AS f2 ON f2.fulltext MATCH $object_fts
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
             AND r2.id = t2.id

--- a/query/match_subject_object_geom_intersects_autocomplete.sql
+++ b/query/match_subject_object_geom_intersects_autocomplete.sql
@@ -4,7 +4,7 @@ SELECT
 FROM fulltext f1
   JOIN tokens t1 ON (
     f1.rowid = t1.rowid
-    AND f1.fulltext MATCH $subject_quoted
+    AND f1.fulltext MATCH $subject_fts
     AND LIKELY(t1.token = $subject)
   )
     JOIN rtree AS r1 ON t1.id = r1.id
@@ -15,7 +15,7 @@ FROM fulltext f1
         (r1.minY - $threshold) < r2.maxY AND
         (r1.maxY + $threshold) > r2.minY
       )
-        JOIN fulltext AS f2 ON f2.fulltext MATCH $object_quoted OR $object_quoted*
+        JOIN fulltext AS f2 ON f2.fulltext MATCH $object_fts OR $object_fts*
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
             AND r2.id = t2.id


### PR DESCRIPTION
I noticed what appears to be a bug in the code but appears to have no negative effects on the quality of results.

There is a piece of code which replaces all occurrences of space with underscore (`.replace(/ /g, '_')`).

I don't remember exactly why we do this but I assume its to allow us to keep multi-word tokens (such as 'new york') as a single token.

Recently we started using the FTS index more, so we should apply this space->underscore replacement in all parts of the code which use the FTS index.

Now.. why it 'just works' anyway is a bit of a mystery 🤷 

- https://github.com/pelias/placeholder/blob/master/lib/TokenIndex.js#L25-L34
- https://github.com/pelias/placeholder/blob/master/lib/TokenIndex.js#L54