### PR TITLE
use LIKELY() to improve query performance

### DIFF
--- a/query/match_subject_object_geom_intersects.sql
+++ b/query/match_subject_object_geom_intersects.sql
@@ -15,7 +15,7 @@ FROM fulltext f1
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
             AND r2.id = t2.id
-            AND t2.token = $object
+            AND LIKELY(t2.token = $object)
             AND (
               t1.lang = t2.lang OR
               t1.lang IN ('eng', 'und') OR
@@ -23,7 +23,7 @@ FROM fulltext f1
             )
           )
 WHERE f1.fulltext MATCH $subject_quoted
-AND t1.token = $subject
+AND LIKELY(t1.token = $subject)
 GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC
 LIMIT $limit

--- a/query/match_subject_object_geom_intersects_autocomplete.sql
+++ b/query/match_subject_object_geom_intersects_autocomplete.sql
@@ -15,7 +15,7 @@ FROM fulltext f1
           JOIN tokens t2 ON (
             f2.rowid = t2.rowid
             AND r2.id = t2.id
-            AND (t2.token = $object OR t2.token LIKE ($object || '%'))
+            AND LIKELY(t2.token = $object OR t2.token LIKE ($object || '%'))
             AND (
               t1.lang = t2.lang OR
               t1.lang IN ('eng', 'und') OR
@@ -23,7 +23,7 @@ FROM fulltext f1
             )
           )
 WHERE f1.fulltext MATCH $subject_quoted
-AND t1.token = $subject
+AND LIKELY(t1.token = $subject)
 GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC
 LIMIT $limit


### PR DESCRIPTION
the changes in https://github.com/pelias/placeholder/pull/216 introduced a performance regression for the query `san francisco, washington`.

as there are now two methods of matching tokens the query planner may not be sure which to choose, by labelling the new check as [LIKELY](https://www.sqlite.org/lang_corefunc.html#likely) we can give the query planner a hint.