### PR TITLE
rewrite queries for performance

### DIFF
--- a/query/match_subject_object_geom_intersects.sql
+++ b/query/match_subject_object_geom_intersects.sql
@@ -2,7 +2,11 @@ SELECT
   t1.id AS subjectId,
   t2.id as objectId
 FROM fulltext f1
-  JOIN tokens t1 ON f1.rowid = t1.rowid
+  JOIN tokens t1 ON (
+    f1.rowid = t1.rowid
+    AND f1.fulltext MATCH $subject_quoted
+    AND LIKELY(t1.token = $subject)
+  )
     JOIN rtree AS r1 ON t1.id = r1.id
       JOIN rtree AS r2 ON (
         r1.maxZ < r2.minZ AND
@@ -22,8 +26,6 @@ FROM fulltext f1
               t2.lang IN ('eng', 'und')
             )
           )
-WHERE f1.fulltext MATCH $subject_quoted
-AND LIKELY(t1.token = $subject)
 GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC
 LIMIT $limit

--- a/query/match_subject_object_geom_intersects_autocomplete.sql
+++ b/query/match_subject_object_geom_intersects_autocomplete.sql
@@ -2,7 +2,11 @@ SELECT
   t1.id AS subjectId,
   t2.id as objectId
 FROM fulltext f1
-  JOIN tokens t1 ON f1.rowid = t1.rowid
+  JOIN tokens t1 ON (
+    f1.rowid = t1.rowid
+    AND f1.fulltext MATCH $subject_quoted
+    AND LIKELY(t1.token = $subject)
+  )
     JOIN rtree AS r1 ON t1.id = r1.id
       JOIN rtree AS r2 ON (
         r1.maxZ < r2.minZ AND
@@ -22,8 +26,6 @@ FROM fulltext f1
               t2.lang IN ('eng', 'und')
             )
           )
-WHERE f1.fulltext MATCH $subject_quoted
-AND LIKELY(t1.token = $subject)
 GROUP BY t1.id, t2.id
 ORDER BY t1.id ASC, t2.id ASC
 LIMIT $limit


### PR DESCRIPTION
following on from https://github.com/pelias/placeholder/pull/218 this PR rewrites the queries again to help nudge the query planner in the right direction.

previously it didn't really matter if the $subject matching happened in the `ON` or a `WHERE` condition, with the additional matching condition I think its better to have it in the `ON`.