### PR TITLE
Add query combination limit

### DIFF
--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -115,6 +115,8 @@ module.exports.matchSubjectObject = function( subject, object, cb ){
     object = object.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '');
     if( '' === object.trim() ){ return cb( null, [] ); }
 
+    if (this._hasTooManyCombinations(subject, object)) { return cb( null, [] ); }
+
     this._queryAll(
       this.prepare( query.match_subject_object_autocomplete ),
       {
@@ -125,6 +127,8 @@ module.exports.matchSubjectObject = function( subject, object, cb ){
       cb
     );
   } else {
+    if (this._hasTooManyCombinations(subject, object)) { return cb( null, [] ); }
+
     this._queryAll(
       this.prepare( query.match_subject_object ),
       {
@@ -135,6 +139,21 @@ module.exports.matchSubjectObject = function( subject, object, cb ){
       cb
     );
   }
+};
+
+module.exports._hasTooManyCombinations = function(subject, object) {
+
+  const terms = [ subject, object ];
+
+  const stmt = this.prepare('SELECT count(*) as cnt from fulltext where fulltext.fulltext = ?');
+
+  const counts = terms.map(function(token) {
+    return stmt.get(token).cnt;
+  });
+
+  const combinations = counts.reduce((a, b) => a * b, 1);
+
+  return combinations >= 1e6;
 };
 
 module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb ){
@@ -151,6 +170,8 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
     object = object.replace(/ /g, '_').replace(REMOVE_PARTIAL_TOKEN_REGEX, '');
     if( '' === object.trim() ){ return cb( null, [] ); }
 
+    if (this._hasTooManyCombinations(subject, object)) { return cb( null, [] ); }
+
     this._queryAll(
       this.prepare( query.match_subject_object_geom_intersects_autocomplete ),
       {
@@ -164,6 +185,8 @@ module.exports.matchSubjectObjectGeomIntersects = function( subject, object, cb 
       cb
     );
   } else {
+    if (this._hasTooManyCombinations(subject, object)) { return cb( null, [] ); }
+
     this._queryAll(
       this.prepare( query.match_subject_object_geom_intersects ),
       {


### PR DESCRIPTION
Recently, we've noticed some queries sent to Placeholder that take a very long time to complete (upwards of 30 seconds depending on the CPU Placeholder is running on).

Because Placeholder is a Node.js process that makes synchronous SQL queries to SQLite, slow queries are a big problem: they slow down all other queries being sent to that same Node.js process. This can be somewhat worked around by the `cluster` module built into Node.js, but overall slow queries are simply very bad and hard to work around

Causes
======

The ultimate cause of these slow queries is that some of the Placeholder SQL queries have logic like: "find all records with tokens in this list, parented by all records with tokens in this other list".

If either or both of those lists of tokens are very common, it's possible for the number of combinations to explode into the tens of millions.

Even though the amount of data in a full planet Placeholder build is fairly small, this can of course end up quite slow.

The Fix
=======

Instead of attempting to write queries that will always be fast, which is probably difficult and would require huge changes to the Placeholder logic, this PR attempts to detect queries that would be too slow, and prevent them from being run.

In practice, this works out very well, as Pelias in general can handle empty results coming back from Placeholder if needed. In general Placeholder will run many similar SQL queries, so there might be results from another SQL query, even if one is skipped because it would be too slow.

It's _strictly_ better than the behavior before this PR, which is that sometimes a very slow query would effectively cause many fast queries to become slow.