### PR TITLE
chore(tests): Replace problematic deepEquals with simpler assertions

### DIFF
--- a/test/lib/Database.js
+++ b/test/lib/Database.js
@@ -95,12 +95,8 @@ module.exports.prepare = function(test, common) {
 
     t.true(typeof db.stmt, 'object');
     t.true(db.stmt.hasOwnProperty(sql));
-    t.deepEqual(db.stmt[sql], {
-      reader: true,
-      readonly: true,
-      source: 'SELECT * FROM sqlite_master',
-      database: db.db
-    });
+    t.true(db.stmt[sql].reader);
+    t.equal(db.stmt[sql].source, sql, 'sql query should be as expected');
 
     t.end();
   });


### PR DESCRIPTION
This test is probably diving too far into the implementation details of what we care about, and can fail on different SQLite versions

For example, as of this writing (2022/02/07), Ubuntu 20.04 on GitHub actions uses SQLite 3.31, where the test fails. My machine has SQLite 3.35, where it passes.