### PR TITLE
improve quoting of token count query

### DIFF
--- a/lib/Queries.js
+++ b/lib/Queries.js
@@ -142,15 +142,10 @@ module.exports.matchSubjectObject = function( subject, object, cb ){
 };
 
 module.exports._hasTooManyCombinations = function(subject, object) {
-
   const terms = [ subject, object ];
+  const stmt = this.prepare(query.count_tokens);
 
-  const stmt = this.prepare('SELECT count(*) as cnt from fulltext where fulltext.fulltext = ?');
-
-  const counts = terms.map(function(token) {
-    return stmt.get(token).cnt;
-  });
-
+  const counts = terms.map(token => stmt.get({ token_quoted: `"${token}"` }).cnt);
   const combinations = counts.reduce((a, b) => a * b, 1);
 
   return combinations >= 1e6;

--- a/query/count_tokens.sql
+++ b/query/count_tokens.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*) AS cnt
+FROM fulltext AS ft
+WHERE ft.fulltext MATCH $token_quoted


### PR DESCRIPTION
There appears to be a bug when using the token count query with reserved tokens such as `#`.
This PR wraps that query in the same way we wrap the other ones to it can accept any characters as input.

```bash
npm run cli -- 'san fran #1'

> pelias-placeholder@0.0.0-development cli
> node cmd/cli.js "san fran #1"

san fran #1


/Users/peter/code/pelias/placeholder/lib/Queries.js:151
    return stmt.get(token).cnt;
                ^
SqliteError: fts5: syntax error near "#"
    at /Users/peter/code/pelias/placeholder/lib/Queries.js:151:17
    at Array.map (<anonymous>)
```