### PR TITLE
Upgrade `better-sqlite3` to 8.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/pelias/placeholder#readme",
   "dependencies": {
     "async": "^3.0.1",
-    "better-sqlite3": "^7.4.3",
+    "better-sqlite3": "^8.5.0",
     "express": "^4.15.2",
     "lodash": "^4.17.21",
     "lower-case": "^2.0.0",


### PR DESCRIPTION
This keeps us up to date with this critical project, allows using prebuilt packages for modern Node.js and Ubuntu versions, etc

https://github.com/pelias/pelias/issues/951
https://github.com/pelias/pelias/issues/950