### PR TITLE
support reserved "constructor" token

### DIFF
--- a/prototype/tokenize.js
+++ b/prototype/tokenize.js
@@ -84,11 +84,11 @@ function _groups(tokens, phrases) {
   // key is a single word token (the first word in
   // the phrase) and the values is an array of
   // phrases which contain that word.
-  const index = {};
+  const index = Object.create(null);
   phrases.forEach( phrase => {
     const words = phrase.split(/\s+/);
     const firstWord = words[0];
-    if( !index.hasOwnProperty( firstWord ) ){
+    if( !index[ firstWord ] ){
       index[ firstWord ] = [];
     }
     index[ firstWord ].push( words );

--- a/test/prototype/tokenize.js
+++ b/test/prototype/tokenize.js
@@ -177,6 +177,17 @@ module.exports._groups = function(test, common) {
     t.deepEqual(tokenize._groups(tokens, phrases), expected);
     t.end();
   });
+
+  // https://github.com/pelias/placeholder/issues/231
+  test('_groups "constructor"', function(t) {
+
+    const tokens = ['constructor'];
+    const phrases = [];
+    const expected = [];
+
+    t.deepEqual(tokenize._groups(tokens, phrases), expected);
+    t.end();
+  });
 };
 
 // 


### PR DESCRIPTION
resolves https://github.com/pelias/placeholder/issues/231

ref: https://stackoverflow.com/questions/21320256/is-there-a-way-to-make-constructor-a-valid-key-in-a-js-object