### PR TITLE
Update better-sqlite3 to v11.5.0

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pelias-blacklist-stream": "^1.1.0",
     "pelias-config": "^4.5.0",
     "pelias-logger": "^1.2.1",
-    "pelias-whosonfirst": "^5.0.0",
+    "pelias-whosonfirst": "^7.2.0",
     "regenerate": "^1.4.2",
     "remove-accents-diacritics": "^1.0.2",
     "require-dir": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/pelias/placeholder#readme",
   "dependencies": {
     "async": "^3.0.1",
-    "better-sqlite3": "^8.5.0",
+    "better-sqlite3": "^11.5.0",
     "express": "^4.15.2",
     "lodash": "^4.17.21",
     "lower-case": "^2.0.0",


### PR DESCRIPTION
This (and a `pelias-whosonfirst`) dependency update gets us Node.js 22 support.

https://github.com/pelias/pelias/issues/950