### PR TITLE
extract: Detect location of whosonfirst data from pelias.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,12 +321,16 @@ the database is created from geographic data sourced from the [whosonfirst](http
 
 the whosonfirst project is distributed as geojson files, so in order to speed up development we first extract the relevant data in to a file: `data/wof.extract`.
 
-the following command will iterate over all the `geojson` files under the `WOF_DIR` path, extracting the relevant properties in to the file `data/wof.extract`.
+the following command will iterate over all the `geojson` files downloaded by the Pelias whosonfirst importer, extracting the relevant properties in to the file `data/wof.extract`.
 
 this process can take 30-60 minutes to run and consumes ~350MB of disk space, you will only need to run this command once, or when your local `whosonfirst-data` files are updated.
 
 ```bash
-$ WOF_DIR=/data/whosonfirst-data/data npm run extract
+$ npm run extract
+
+# alternative if you do not have a `pelias.json` file specifying where WOF data should be
+$ WOF_DIR=/path/to/your/whosonfirst/data npm run extract
+
 ```
 
 now you can rebuild the `data/store.json` file with the following command:

--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -9,7 +9,8 @@ const combinedStream = require('combined-stream');
 
 const SQLITE_REGEX = /whosonfirst-data-[a-z0-9-]+\.db$/;
 
-const WOF_DIR = process.env.WOF_DIR || '/data/whosonfirst-data/sqlite';
+// Use WOF_DIR env variable when available, otherwise use the location specified in pelias.json
+const WOF_DIR = process.env.WOF_DIR || path.join(config.datapath, 'sqlite');
 
 const layers = fs.readFileSync(path.join(__dirname, 'placetype.filter'), 'utf-8')
                   .replace(/^.*\(/, '') // Removes all characters before the first parenthesis


### PR DESCRIPTION
This change allows the Placeholder extract script to work in most cases _without_ specifying the `WOF_DIR` environment variable.

Previously, unless you were using the particular arrangement of files and directories from pelias/docker, the default location the extract script looks for data (`/data/whosonfirst-data/sqlite`) was probably not correct.

I noticed this inconvenience when running Pelias locally _without_ docker for the first time in quite a long time.

My guess/recollection is an older version of the extract script (pre-sqlite) was pure bash, and so checking `pelias.json` was less convenient than in the current Node.js script.

The `WOF_DIR` environment variable is left as an override, but my hope is with this change almost no one would have to use it.