### PR TITLE
Remove hardcoded `WOF_DIR` env var from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN npm install
 # copy code from local checkout
 ADD . ${WORKDIR}
 
-ENV WOF_DIR '/data/whosonfirst/sqlite'
 ENV PLACEHOLDER_DATA '/data/placeholder'
 
 USER pelias


### PR DESCRIPTION
following up from https://github.com/pelias/placeholder/pull/235, this small change makes it easier to configure where Placeholder looks for data within `pelias.json`.

On it's own, this change won't make any difference for the vast majority of people using the pelias/docker setup, as the path hardcoded in the Dockerfile and in `pelias.json` in the projects are the same.

However, on the off chance someone is making changes to their `pelias.json`, removing this line will mean that change can actually take effect.

In general, going forward, only very unsual situations should require someone to set `WOF_DIR` at all.