### PR TITLE
Allow graceful shutdown

### DIFF
--- a/server/http.js
+++ b/server/http.js
@@ -109,6 +109,7 @@ function handler() {
     logger.info('Placeholder service shutting down');
     for (const id in cluster.workers) {
       cluster.workers[id].kill('SIGINT');
+      cluster.workers[id].disconnect();
     }
   }
 


### PR DESCRIPTION
Recently I've notice that when running Placeholder locally (without Docker), it doesn't respond correctly to ctrl+C.

The service prints a shutdown message, and stops serving requests, but doesn't terminate.

After some investigation using Node's tools to print open file handles and any pending I/O requests, it turns out ironically the connection between the primary process and the worker processes is what is preventing the graceful shutdown.

The fix is simple, have the primary process sever the connection to the workers, then they all shut down.