### PR TITLE
Update more demo libraries

### DIFF
--- a/server/demo/index.html
+++ b/server/demo/index.html
@@ -4,9 +4,11 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 	<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.7/underscore-umd-min.js"></script>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js"></script>
@@ -41,6 +43,12 @@
         padding: 2px;
         /*padding-right: 0px;*/
         font-style: normal;
+      }
+
+      .btn-tokens{
+        --bs-btn-color: var(--bs-gray-dark);
+        --bs-btn-bg: var(--bs-white);
+        --bs-btn-border-color: var(--bs-border-color);
       }
     </style>
 
@@ -136,7 +144,7 @@
         // display token groups
         groups.forEach( function( win ){
           var buttons = win.map( function( token ){
-            return '<li type="button" class="btn btn-default" style="margin-top: 5px;"><span>' + token + '</span></li>';
+            return '<li type="button" class="btn btn-light btn-tokens" style="margin-top: 5px"><span>' + token + '</span></li>';
           });
           $("#tokens").html('<li><ul style="margin: 0; padding: 5px; padding-top: 0; list-style: none; background-color: #efefef; margin-bottom: 5px;">' + buttons.join('\n') + '</ul></li>' );
         });
@@ -305,13 +313,11 @@
           <div class="col-md-6">
 
             <div class="input-group">
-              <span class="input-group-addon">
-                <input id="live" type="checkbox" checked="checked" />
-              </span>
+              <div class="input-group-text">
+                <input id="live" class="form-check-input mt-0" type="checkbox" checked="checked" />
+              </div>
               <input id="text" type="text" class="form-control" placeholder="Search for...">
-              <span class="input-group-btn">
-                <button id="go" class="btn btn-default" type="button">Parse!</button>
-              </span>
+              <button id="go" class="btn btn-primary" type="button">Parse!</button>
             </div><!-- /input-group -->
 
             <ul id="tokens" class="btn-group" role="group" style="margin-top:10px; list-style: none;"></ul>

--- a/server/demo/index.html
+++ b/server/demo/index.html
@@ -6,11 +6,11 @@
 	<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/async/2.1.4/async.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.7/underscore-umd-min.js"></script>
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 
     <style>
       .wofinfo {


### PR DESCRIPTION
Building on https://github.com/pelias/placeholder/pull/238, this updates the rest of the libraries used by the demo page: underscore, Bootstrap, and Leaflet.

I also removed an `async` library that doesn't seem to be needed for anything.

For Bootstrap, I also had to make some minor CSS tweaks both to get the buttons and addons to render properly, but moreso to make sure the color of the token display was similar to before. Nothing too complex though.