### PR TITLE
Allow SQLite files in WoF-Root

### DIFF
--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -10,7 +10,7 @@ const combinedStream = require('combined-stream');
 const SQLITE_REGEX = /whosonfirst-data-[a-z0-9-]+\.db$/;
 
 // Use WOF_DIR env variable when available, otherwise use the location specified in pelias.json
-const WOF_DIR = process.env.WOF_DIR || path.join(config.datapath, 'sqlite');
+const WOF_DIR = process.env.WOF_DIR ? [process.env.WOF_DIR] : [path.join(config.datapath), path.join(config.datapath, 'sqlite')];
 
 const layers = fs.readFileSync(path.join(__dirname, 'placetype.filter'), 'utf-8')
                   .replace(/^.*\(/, '') // Removes all characters before the first parenthesis
@@ -45,19 +45,28 @@ const output = () => {
 };
 
 const sqliteStream = combinedStream.create();
-fs.readdirSync(WOF_DIR)
-  .filter(file => SQLITE_REGEX.test(file))
-  .map(file => path.join(WOF_DIR, file))
-  .forEach(dbPath => {
-    sqliteStream.append(next => {
-      next(new SQLiteStream(
-        dbPath,
-        config.importPlace ?
-        SQLiteStream.findGeoJSONByPlacetypeAndWOFId(layers, config.importPlace) :
-        SQLiteStream.findGeoJSONByPlacetype(layers)
-      ));
-    });
-  });
+WOF_DIR.forEach(dir => {
+  fs.readdirSync(dir)
+    .filter(file => SQLITE_REGEX.test(file))
+    .map(file => {
+      if (fs.existsSync(path.join(config.datapath, 'sqlite', file))) {
+        return path.join(config.datapath, 'sqlite', file);
+      }
+      else {
+        return path.join(config.datapath, file);
+      }
+    })
+    .forEach(dbPath => {
+      sqliteStream.append(next => {
+        next(new SQLiteStream(
+          dbPath,
+          config.importPlace ?
+            SQLiteStream.findGeoJSONByPlacetypeAndWOFId(layers, config.importPlace) :
+            SQLiteStream.findGeoJSONByPlacetype(layers)
+        ));
+      });
+    })
+});
 
 sqliteStream
   .pipe(whosonfirst.toJSONStream())

--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -13,13 +13,13 @@ const SQLITE_REGEX = /whosonfirst-data-[a-z0-9-]+\.db$/;
 const WOF_DIR = process.env.WOF_DIR ? [process.env.WOF_DIR] : [path.join(config.datapath), path.join(config.datapath, 'sqlite')];
 
 const layers = fs.readFileSync(path.join(__dirname, 'placetype.filter'), 'utf-8')
-                  .replace(/^.*\(/, '') // Removes all characters before the first parenthesis
-                  .match(/[a-z]+/g); // Get the layer list
+  .replace(/^.*\(/, '') // Removes all characters before the first parenthesis
+  .match(/[a-z]+/g); // Get the layer list
 
 const jq_filter = fs.readFileSync(path.join(__dirname, 'jq.filter'), 'utf-8')
-                    .match(/test\("(.*)"\)/g) // Get all tests
-                    .map(s => s.replace(/^[^"]+"/, '').replace(/"[^"]+$/, '')) // Get only regex part
-                    .map(s => new RegExp(s)); // Transform it into JS RegExp
+  .match(/test\("(.*)"\)/g) // Get all tests
+  .map(s => s.replace(/^[^"]+"/, '').replace(/"[^"]+$/, '')) // Get only regex part
+  .map(s => new RegExp(s)); // Transform it into JS RegExp
 
 const output = () => {
   if (process.argv.length > 2 && process.argv[2] === 'build') {
@@ -45,35 +45,38 @@ const output = () => {
 };
 
 const sqliteStream = combinedStream.create();
+//TODO: If "sqlite" does not exists extract 
 WOF_DIR.forEach(dir => {
-  fs.readdirSync(dir)
-    .filter(file => SQLITE_REGEX.test(file))
-    .map(file => {
-      if (fs.existsSync(path.join(config.datapath, 'sqlite', file))) {
-        return path.join(config.datapath, 'sqlite', file);
-      }
-      else {
-        return path.join(config.datapath, file);
-      }
-    })
-    .forEach(dbPath => {
-      sqliteStream.append(next => {
-        next(new SQLiteStream(
-          dbPath,
-          config.importPlace ?
-            SQLiteStream.findGeoJSONByPlacetypeAndWOFId(layers, config.importPlace) :
-            SQLiteStream.findGeoJSONByPlacetype(layers)
-        ));
+  if (fs.existsSync(dir)) {
+    fs.readdirSync(dir)
+      .filter(file => SQLITE_REGEX.test(file))
+      .map(file => {
+        if (fs.existsSync(path.join(config.datapath, 'sqlite', file))) {
+          return path.join(config.datapath, 'sqlite', file);
+        }
+        else {
+          return path.join(config.datapath, file);
+        }
+      })
+      .forEach(dbPath => {
+        sqliteStream.append(next => {
+          next(new SQLiteStream(
+            dbPath,
+            config.importPlace ?
+              SQLiteStream.findGeoJSONByPlacetypeAndWOFId(layers, config.importPlace) :
+              SQLiteStream.findGeoJSONByPlacetype(layers)
+          ));
+        });
       });
-    });
+  }
 });
 
 sqliteStream
   .pipe(whosonfirst.toJSONStream())
   .pipe(through.obj((row, _, next) => {
     Object.keys(row.properties)
-          .filter(key => !jq_filter.some(regex => regex.test(key)))
-          .forEach(key => delete row.properties[key]);
+      .filter(key => !jq_filter.some(regex => regex.test(key)))
+      .forEach(key => delete row.properties[key]);
     next(null, row.properties);
   }))
   .pipe(output());

--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -45,7 +45,6 @@ const output = () => {
 };
 
 const sqliteStream = combinedStream.create();
-//TODO: If "sqlite" does not exists extract 
 WOF_DIR.forEach(dir => {
   if (fs.existsSync(dir)) {
     fs.readdirSync(dir)

--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -65,7 +65,7 @@ WOF_DIR.forEach(dir => {
             SQLiteStream.findGeoJSONByPlacetype(layers)
         ));
       });
-    })
+    });
 });
 
 sqliteStream


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
Follow up on [pelias/whosonfirst#557](https://github.com/pelias/whosonfirst/pull/557) to also allow the placeholder to use sqlite files which are not in the sqlite directory.

---
#### Here's what actually got changed :clap:
The 'WOF_DIR' variable is now a string array set to '[config.datapath, config.datapath.sqlite]' if 'process.env.WOF_DIR' is not set. The correct path for each file is determined and saved for importing from both directories. The same logic applies as in https://github.com/pelias/whosonfirst/pull/557: if a file with the same name exists in both the root directory and the sqlite directory, the sqlite file will be used.

---
#### Here's how others can test the changes :eyes:

1. Check out the PR.
2. Put some files in the WOF root directory/sqlite directory.
3. Run the command 'npm run extract' and check that all databases have been imported into `wof.extract`.