### PR TITLE
extract: improve jq filter speed

### DIFF
--- a/cmd/jq.filter
+++ b/cmd/jq.filter
@@ -1,19 +1,19 @@
 .properties | with_entries(
-  select( .key |
-    test("^wof:(id|name|placetype|hierarchy|parent_id|country_alpha3|abbreviation|shortcode|superseded_by|label|population|megacity)$"),
-    test("^lbl:(bbox|latitude|longitude)$"),
-    test("^geom:(area|bbox|latitude|longitude)$"),
-    test("^iso:(country)$"),
-    test("^ne:(iso_a2|iso_a3|pop_est)$"),
-    test("^edtf:(deprecated)$"),
-    test("^mz:(is_current|population)$"),
-    test("^gn:(population|pop)$"),
-    test("^zs:(pop10)$"),
-    test("^qs:(pop|gn_pop|photo_sum)$"),
-    test("^wk:(population)$"),
-    test("^meso:(pop)$"),
-    test("^statoids:(population)$"),
-    test("^name:"),
-    test("^abrv:")
-  )
+  select(.key | test(
+    "^(wof:(id|name|placetype|hierarchy|parent_id|country_alpha3|abbreviation|shortcode|superseded_by|label|population|megacity)$|" +
+    "lbl:(bbox|latitude|longitude)$|" +
+    "geom:(area|bbox|latitude|longitude)$|" +
+    "iso:(country)$|" +
+    "ne:(iso_a2|iso_a3|pop_est)$|" +
+    "edtf:(deprecated)$|" +
+    "mz:(is_current|population)$|" +
+    "gn:(population|pop)$|" +
+    "zs:(pop10)$|" +
+    "qs:(pop|gn_pop|photo_sum)$|" +
+    "wk:(population)$|" +
+    "meso:(pop)$|" +
+    "statoids:(population)$|" +
+    "name:|" +
+    "abrv:)"
+  ))
 )


### PR DESCRIPTION
with the help of AI I was able to improve the speed of the `jq` filter used to generate the extract file.
I've validated the change using `shasum` and `diff` to ensure it's identical and confirmed the timing.

here's what Claude has to say

## Optimize jq filter performance by consolidating regex patterns

Improved jq filter performance by combining 15 separate `test()` calls into a single regex pattern with alternation.

**Performance:**
- Before: 33.5s
- After: 24.0s  
- **~40% faster**

**Changes:**
- Consolidated multiple sequential `test()` calls into one pattern using regex `|` alternation
- Reduced regex compilation overhead from 15 patterns to 1
- Maintained identical output and filtering logic