### PR TITLE
Remove unused dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # base image
 FROM pelias/baseimage
 
-# downloader apt dependencies
-# note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y jq lbzip2 parallel && rm -rf /var/lib/apt/lists/*
-
 # change working dir
 ENV WORKDIR /code/pelias/placeholder
 WORKDIR ${WORKDIR}


### PR DESCRIPTION
`lbzip2` is already installed in the baseimage, and `parallel` appears to be unused. It was likely previously used in the downloaders, but that must have been long ago.