### PR TITLE
Use Placeholder.js as the "main" file exported in the NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "author": "mapzen",
   "license": "MIT",
-  "main": "server.js",
+  "main": "Placeholder.js",
   "scripts": {
     "test": "npm run units",
     "units": "./cmd/units",


### PR DESCRIPTION
The old value, "server.js" seems to have moved years ago.

`Placeholder.js` contains most of the primary interfaces required for Placeholder operation. By exporting it, other code can call `require('pelias-placeholder')` and then use Placeholder functionality fairly easily