### PR TITLE
Fix import record checks that would never pass

### DIFF
--- a/cmd/jq.filter
+++ b/cmd/jq.filter
@@ -1,6 +1,6 @@
 .properties | with_entries(
   select(.key | test(
-    "^(wof:(id|name|placetype|hierarchy|parent_id|country_alpha3|abbreviation|shortcode|superseded_by|label|population|megacity)$|" +
+    "^(wof:(id|name|placetype|hierarchy|parent_id|country_alpha3|abbreviation|shortcode|superseded_by|label|population|megacity|capital_of)$|" +
     "lbl:(bbox|latitude|longitude)$|" +
     "geom:(area|bbox|latitude|longitude)$|" +
     "iso:(country)$|" +

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -103,8 +103,8 @@ function insertWofRecord( wof, next ){
     // see: https://github.com/whosonfirst-data/whosonfirst-data/issues/799
     const hasDeadOrObscureLanguages = _.has(wof, 'name:vol_x_preferred');
     const isLowOrUnknownPopulation = _.get(doc, 'population', 0) < LOW_POPULATION_THRESHOLD;
-    const isMegaCity = _.get(doc, 'wof:megacity', 0) === 1;
-    const isCapitalCity = !_.isEmpty(_.get(doc, 'wof:capital_of'));
+    const isMegaCity = _.get(wof, 'wof:megacity', 0) === 1;
+    const isCapitalCity = !_.isEmpty(_.get(wof, 'wof:capital_of'));
     const isLikelyTransliterated = (
       hasDeadOrObscureLanguages && isLowOrUnknownPopulation && !isMegaCity && !isCapitalCity
     );

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -942,6 +942,34 @@ module.exports.add_names = function(test, util) {
     });
   });
 
+  // isLikelyTransliterated: megacity flag (read from the raw wof record, not the
+  // partially-built doc) should rescue names from being dropped
+  test( 'store: do not reject likely-transliterated names for megacities', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord(params({
+      'name:vol_x_preferred': [ 'Example' ],
+      'name:eng_x_preferred': [ 'Big City' ],
+      'wof:megacity': 1
+    }), function(){
+      t.ok( mock._calls.setTokens[0][1].length > 0 );
+      t.end();
+    });
+  });
+
+  // isLikelyTransliterated: capital_of flag (read from the raw wof record, not the
+  // partially-built doc) should rescue names from being dropped
+  test( 'store: do not reject likely-transliterated names for capital cities', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord(params({
+      'name:vol_x_preferred': [ 'Example' ],
+      'name:eng_x_preferred': [ 'Capital City' ],
+      'wof:capital_of': [ 123 ]
+    }), function(){
+      t.ok( mock._calls.setTokens[0][1].length > 0 );
+      t.end();
+    });
+  });
+
   // do not store tokens for the 'empire' placetype
   test( 'empire tokens excluded', function(t) {
     var mock = new Mock();


### PR DESCRIPTION
During Placeholder import, we check records for suspect translations by looking at a few properties including if the record is a megacity, has population, is a capital city, etc.

However most of those checks were failing because of simple typos/omissions.

The existing code, when looking for record population and megacity status checked the `doc` variable, which is the Placeholder record in the process of being built, rather than the `wof` variable, which is the WOF record data from the WOF database. Only the latter has the population and `megacity` status.

Similarly, the `capital_of` value was not being brought in from the WOF DB, so that check would always fail.

As it turns out, there aren't really any effects, currently, from these typos, but they are good to fix anyway.