### PR TITLE
Improve junk transliteration detection

### DIFF
--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -6,15 +6,27 @@ const SQLiteStream = whosonfirst.SQLiteStream;
 const through = require('through2');
 const Placeholder = require('../Placeholder');
 const combinedStream = require('combined-stream');
+const wof = require('../prototype/wof');
+const buildDescendantPopulationIndex = require('../lib/descendantPopulationIndex');
+
+const DESCENDANT_POPULATION_PROPERTY = wof.DESCENDANT_POPULATION_PROPERTY;
 
 const SQLITE_REGEX = /whosonfirst-data-[a-z0-9-]+\.db$/;
 
 // Use WOF_DIR env variable when available, otherwise use the location specified in pelias.json
 const WOF_DIR = process.env.WOF_DIR || path.join(config.datapath, 'sqlite');
 
+const dbFiles = fs.readdirSync(WOF_DIR)
+  .filter(file => SQLITE_REGEX.test(file))
+  .map(file => path.join(WOF_DIR, file));
+
 const layers = fs.readFileSync(path.join(__dirname, 'placetype.filter'), 'utf-8')
                   .replace(/^.*\(/, '') // Removes all characters before the first parenthesis
                   .match(/[a-z]+/g); // Get the layer list
+
+console.error('building descendant population index...');
+const descendantPopulationIndex = buildDescendantPopulationIndex(dbFiles, layers);
+console.error(`descendant population index built, ${descendantPopulationIndex.size} records have a populous descendant`);
 
 const jq_filter = new RegExp(
   fs.readFileSync(path.join(__dirname, 'jq.filter'), 'utf-8')
@@ -47,19 +59,16 @@ const output = () => {
 };
 
 const sqliteStream = combinedStream.create();
-fs.readdirSync(WOF_DIR)
-  .filter(file => SQLITE_REGEX.test(file))
-  .map(file => path.join(WOF_DIR, file))
-  .forEach(dbPath => {
-    sqliteStream.append(next => {
-      next(new SQLiteStream(
-        dbPath,
-        config.importPlace ?
-        SQLiteStream.findGeoJSONByPlacetypeAndWOFId(layers, config.importPlace) :
-        SQLiteStream.findGeoJSONByPlacetype(layers)
-      ));
-    });
+dbFiles.forEach(dbPath => {
+  sqliteStream.append(next => {
+    next(new SQLiteStream(
+      dbPath,
+      config.importPlace ?
+      SQLiteStream.findGeoJSONByPlacetypeAndWOFId(layers, config.importPlace) :
+      SQLiteStream.findGeoJSONByPlacetype(layers)
+    ));
   });
+});
 
 sqliteStream
   .pipe(whosonfirst.toJSONStream())
@@ -68,5 +77,15 @@ sqliteStream
           .filter(key => !jq_filter.test(key))
           .forEach(key => delete row.properties[key]);
     next(null, row.properties);
+  }))
+  .pipe(through.obj((row, _, next) => {
+    // attach the precomputed descendant population, if any, so wof.js's
+    // isLikelyTransliterated check can use it without needing DB access
+    const id = parseInt(row['wof:id'], 10);
+    const maxDescendantPopulation = descendantPopulationIndex.get(id);
+    if (maxDescendantPopulation !== undefined) {
+      row[DESCENDANT_POPULATION_PROPERTY] = maxDescendantPopulation;
+    }
+    next(null, row);
   }))
   .pipe(output());

--- a/lib/descendantPopulationIndex.js
+++ b/lib/descendantPopulationIndex.js
@@ -1,0 +1,93 @@
+
+// Builds a `Map<wof:id, maxDescendantPopulation>` from the WOF sqlite `ancestors`
+// table, so that admin polygons with no population of their own (eg. macrocounties)
+// can be recognised as non-obscure when they contain a populous descendant.
+//
+// see: prototype/wof.js `isLikelyTransliterated`
+
+const Database = require('better-sqlite3');
+const wof = require('../prototype/wof');
+
+/**
+ * Pass 1: collect the population of every record among `dbFiles` whose
+ * placetype is in `layers` (the same filter used for the main extraction).
+ *
+ * @param {string[]} dbFiles
+ * @param {string[]} layers
+ * @returns {Map<number, number>} id -> population
+ */
+function collectPopulations( dbFiles, layers ){
+  const idToPopulation = new Map();
+
+  dbFiles.forEach( dbPath => {
+    const db = new Database( dbPath, { readonly: true } );
+    const stmt = db.prepare(`
+      SELECT geojson.id, geojson.body
+      FROM geojson
+      JOIN spr ON geojson.id = spr.id
+      WHERE geojson.id != 1
+        AND geojson.is_alt != 1
+        AND spr.is_deprecated = 0
+        AND spr.is_superseded = 0
+        AND spr.placetype IN ('${layers.join('\',\'')}')
+    `);
+
+    for( const row of stmt.iterate() ){
+      let properties;
+      try {
+        properties = JSON.parse( row.body ).properties;
+      } catch( e ){
+        continue;
+      }
+      const population = parseInt( wof.getPopulation( properties ), 10 );
+      if( Number.isFinite( population ) && population > 0 ){
+        idToPopulation.set( row.id, population );
+      }
+    }
+
+    db.close();
+  });
+
+  return idToPopulation;
+}
+
+/**
+ * Pass 2: roll each record's population up to every one of its WOF ancestors,
+ * keeping the highest value seen per ancestor.
+ *
+ * @param {string[]} dbFiles
+ * @param {Map<number, number>} idToPopulation
+ * @returns {Map<number, number>} ancestor id -> max descendant population
+ */
+function rollUpToAncestors( dbFiles, idToPopulation ){
+  const descendantPopulation = new Map();
+
+  dbFiles.forEach( dbPath => {
+    const db = new Database( dbPath, { readonly: true } );
+    const stmt = db.prepare('SELECT id, ancestor_id FROM ancestors');
+
+    for( const row of stmt.iterate() ){
+      const population = idToPopulation.get( row.id );
+      if( population === undefined ){ continue; }
+
+      const existing = descendantPopulation.get( row.ancestor_id ) || 0;
+      if( population > existing ){
+        descendantPopulation.set( row.ancestor_id, population );
+      }
+    }
+
+    db.close();
+  });
+
+  return descendantPopulation;
+}
+
+/**
+ * @param {string[]} dbFiles - absolute paths to whosonfirst-data-*.db files
+ * @param {string[]} layers - wof:placetype values to consider for population data
+ * @returns {Map<number, number>} wof:id -> highest population found among its descendants
+ */
+module.exports = function buildDescendantPopulationIndex( dbFiles, layers ){
+  const idToPopulation = collectPopulations( dbFiles, layers );
+  return rollUpToAncestors( dbFiles, idToPopulation );
+};

--- a/prototype/wof.js
+++ b/prototype/wof.js
@@ -8,6 +8,11 @@ const analysis = require('../lib/analysis');
 const language = dir('../config/language');
 const LOW_POPULATION_THRESHOLD = 2000;
 
+// synthetic property injected by cmd/wof_extract_sqlite.js (see lib/descendantPopulationIndex.js)
+// carrying the highest population found among a record's WOF descendants, since many admin
+// polygons (eg. macrocounties) have no population of their own but clearly aren't obscure.
+const DESCENDANT_POPULATION_PROPERTY = 'placeholder:max_descendant_population';
+
 // list of languages / tags we favour in cases of deduplication
 const LANG_PREFS = ['eng','und'];
 const TAG_PREFS = ['preferred','abbr','label','variant','colloquial'];
@@ -98,17 +103,7 @@ function insertWofRecord( wof, next ){
       }
     }
 
-    // note: skip all `name:*` fields when we suspect that they were sourced from
-    // machine transliteration via WikiData.
-    // see: https://github.com/whosonfirst-data/whosonfirst-data/issues/799
-    const hasDeadOrObscureLanguages = _.has(wof, 'name:vol_x_preferred');
-    const isLowOrUnknownPopulation = _.get(doc, 'population', 0) < LOW_POPULATION_THRESHOLD;
-    const isMegaCity = _.get(wof, 'wof:megacity', 0) === 1;
-    const isCapitalCity = !_.isEmpty(_.get(wof, 'wof:capital_of'));
-    const isLikelyTransliterated = (
-      hasDeadOrObscureLanguages && isLowOrUnknownPopulation && !isMegaCity && !isCapitalCity
-    );
-    if (!isLikelyTransliterated) {
+    if (!isLikelyTransliterated(wof, doc.population)) {
 
       // add 'name:*' fields
       for( var attr in wof ){
@@ -302,6 +297,25 @@ function getPopulation( wof ) {
   else if( wof['ne:pop_est'] ){             return wof['ne:pop_est']; }
 }
 
+// note: skip all `name:*` fields when we suspect that they were sourced from
+// machine transliteration via WikiData.
+// see: https://github.com/whosonfirst-data/whosonfirst-data/issues/799
+//
+// `populationSelf` is the record's own population (as computed by getPopulation).
+// Many admin polygons (eg. macrocounties) carry no population of their own, so we
+// also allow the record's `placeholder:max_descendant_population` property (see
+// lib/descendantPopulationIndex.js) - the highest population found among its WOF
+// descendants - to rescue it from being treated as obscure.
+function isLikelyTransliterated( wof, populationSelf ) {
+  const hasDeadOrObscureLanguages = _.has(wof, 'name:vol_x_preferred');
+  const isLowOrUnknownPopulation =
+    _.toInteger(populationSelf) < LOW_POPULATION_THRESHOLD &&
+    _.toInteger(wof[DESCENDANT_POPULATION_PROPERTY]) < LOW_POPULATION_THRESHOLD;
+  const isMegaCity = _.get(wof, 'wof:megacity', 0) === 1;
+  const isCapitalCity = !_.isEmpty(_.get(wof, 'wof:capital_of'));
+  return hasDeadOrObscureLanguages && isLowOrUnknownPopulation && !isMegaCity && !isCapitalCity;
+}
+
 // abbreviations and ISO codes
 // logic copied from: pelias/whosonfirst src/components/extractFields.js (since modified)
 // @todo: wof:abbreviation is deprecated, remove references to it
@@ -345,5 +359,8 @@ function validBoundingBox(bbox) {
 module.exports.insertWofRecord = insertWofRecord;
 module.exports.isValidWofRecord = isValidWofRecord;
 module.exports.getPopulation = getPopulation;
+module.exports.isLikelyTransliterated = isLikelyTransliterated;
 module.exports.getAbbreviation = getAbbreviation;
 module.exports.validBoundingBox = validBoundingBox;
+module.exports.DESCENDANT_POPULATION_PROPERTY = DESCENDANT_POPULATION_PROPERTY;
+module.exports.LOW_POPULATION_THRESHOLD = LOW_POPULATION_THRESHOLD;

--- a/test/lib/descendantPopulationIndex.js
+++ b/test/lib/descendantPopulationIndex.js
@@ -1,0 +1,91 @@
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var Database = require('better-sqlite3');
+var buildDescendantPopulationIndex = require('../../lib/descendantPopulationIndex');
+
+// minimal schema matching the tables descendantPopulationIndex.js queries:
+// geojson(id, body, is_alt), spr(id, name, placetype, is_deprecated, is_superseded),
+// ancestors(id, ancestor_id)
+function createFixtureDb( records, ancestorPairs ){
+  var dbPath = path.join( os.tmpdir(), 'placeholder-test-' + Math.random().toString(36).slice(2) + '.db' );
+  var db = new Database( dbPath );
+
+  db.exec(`
+    CREATE TABLE geojson (id INTEGER, body TEXT, is_alt INTEGER);
+    CREATE TABLE spr (id INTEGER, name TEXT, placetype TEXT, is_deprecated INTEGER, is_superseded INTEGER);
+    CREATE TABLE ancestors (id INTEGER, ancestor_id INTEGER);
+  `);
+
+  var insertGeojson = db.prepare('INSERT INTO geojson (id, body, is_alt) VALUES (?, ?, 0)');
+  var insertSpr = db.prepare('INSERT INTO spr (id, name, placetype, is_deprecated, is_superseded) VALUES (?, ?, ?, 0, 0)');
+  var insertAncestor = db.prepare('INSERT INTO ancestors (id, ancestor_id) VALUES (?, ?)');
+
+  records.forEach( r => {
+    insertGeojson.run( r.id, JSON.stringify({ properties: r.properties }) );
+    insertSpr.run( r.id, r.properties['wof:name'], r.properties['wof:placetype'] );
+  });
+
+  ancestorPairs.forEach( ([id, ancestorId]) => {
+    insertAncestor.run( id, ancestorId );
+  });
+
+  db.close();
+  return dbPath;
+}
+
+module.exports.build = function(test) {
+
+  test( 'macrocounty with no population inherits max population from a descendant', function(t) {
+    var dbPath = createFixtureDb([
+      { id: 1, properties: { 'wof:id': 1, 'wof:name': 'Example County', 'wof:placetype': 'macrocounty' } },
+      { id: 2, properties: { 'wof:id': 2, 'wof:name': 'Small Town', 'wof:placetype': 'locality', 'wof:population': 500 } },
+      { id: 3, properties: { 'wof:id': 3, 'wof:name': 'Big Town', 'wof:placetype': 'locality', 'wof:population': 50000 } }
+    ], [
+      [ 2, 1 ], // Small Town is a descendant of Example County
+      [ 3, 1 ]  // Big Town is a descendant of Example County
+    ]);
+
+    var index = buildDescendantPopulationIndex( [ dbPath ], [ 'macrocounty', 'locality' ] );
+    t.equal( index.get(1), 50000, 'macrocounty inherits the highest descendant population' );
+    t.notOk( index.has(2), 'a record is not its own descendant' );
+    t.notOk( index.has(3), 'a leaf record with no descendants has no entry' );
+
+    fs.unlinkSync( dbPath );
+    t.end();
+  });
+
+  test( 'ignores population from placetypes outside the requested layers', function(t) {
+    var dbPath = createFixtureDb([
+      { id: 1, properties: { 'wof:id': 1, 'wof:name': 'Example County', 'wof:placetype': 'macrocounty' } },
+      { id: 2, properties: { 'wof:id': 2, 'wof:name': 'Excluded', 'wof:placetype': 'venue', 'wof:population': 999999 } }
+    ], [
+      [ 2, 1 ]
+    ]);
+
+    var index = buildDescendantPopulationIndex( [ dbPath ], [ 'macrocounty' ] );
+    t.notOk( index.has(1), 'population from an out-of-scope placetype is not counted' );
+
+    fs.unlinkSync( dbPath );
+    t.end();
+  });
+
+  test( 'merges results across multiple db files', function(t) {
+    var dbPathA = createFixtureDb([
+      { id: 1, properties: { 'wof:id': 1, 'wof:name': 'Example County', 'wof:placetype': 'macrocounty' } }
+    ], []);
+    var dbPathB = createFixtureDb([
+      { id: 2, properties: { 'wof:id': 2, 'wof:name': 'Big Town', 'wof:placetype': 'locality', 'wof:population': 12345 } }
+    ], [
+      [ 2, 1 ]
+    ]);
+
+    var index = buildDescendantPopulationIndex( [ dbPathA, dbPathB ], [ 'macrocounty', 'locality' ] );
+    t.equal( index.get(1), 12345, 'ancestor/descendant relationships are resolved across db files' );
+
+    fs.unlinkSync( dbPathA );
+    fs.unlinkSync( dbPathB );
+    t.end();
+  });
+
+};

--- a/test/prototype/wof.js
+++ b/test/prototype/wof.js
@@ -970,6 +970,36 @@ module.exports.add_names = function(test, util) {
     });
   });
 
+  // isLikelyTransliterated: a record with no population of its own (eg. a
+  // macrocounty) should still keep its names if a populous descendant was
+  // found by the pre-pass and attached via the synthetic property
+  test( 'store: do not reject likely-transliterated names when a populous descendant exists', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord(params({
+      'wof:placetype': 'macrocounty',
+      'name:vol_x_preferred': [ 'Example' ],
+      'name:eng_x_preferred': [ 'Greater London' ],
+      'placeholder:max_descendant_population': 7556900
+    }), function(){
+      t.ok( mock._calls.setTokens[0][1].length > 0 );
+      t.end();
+    });
+  });
+
+  // isLikelyTransliterated: a small descendant population should not rescue the record
+  test( 'store: reject likely-transliterated names when descendant population is also low', function(t) {
+    var mock = new Mock();
+    mock.insertWofRecord(params({
+      'wof:placetype': 'macrocounty',
+      'name:vol_x_preferred': [ 'Example' ],
+      'name:eng_x_preferred': [ 'Nowhereshire' ],
+      'placeholder:max_descendant_population': 1999
+    }), function(){
+      t.deepEqual( mock._calls.setTokens, [[ 1, [] ]] );
+      t.end();
+    });
+  });
+
   // do not store tokens for the 'empire' placetype
   test( 'empire tokens excluded', function(t) {
     var mock = new Mock();

--- a/test/units.js
+++ b/test/units.js
@@ -10,6 +10,7 @@ var tests = [
   './lib/DocStore',
   './lib/TokenIndex',
   './lib/Result',
+  './lib/descendantPopulationIndex',
   './prototype/wof',
   './prototype/io',
   './prototype/tokenize',


### PR DESCRIPTION
Back in https://github.com/pelias/placeholder/pull/214 we built some protection into Placeholder from WOF records that have what look like very bad machine translieration of names in to basically every language.

A good example is the already-dubious neighbourhood of [Dolphin](https://spelunker.whosonfirst.org/id/85887025), which has 94 translated names.

To find cases like this we check for records that are not a megacity, have under 2000 (or no) population, is not a capital city, and has translations in the Volapük language. Volapük is a constructed language invented in the 1890s that doesn't really have real world use.

These four properties combine to pretty effectively filter out incorrect or low quality (or just noisy) translations, but there are a few valid cases it all filters out.

Mostly these are lower-frequency placetypes that lack population info, like the [Greater London](https://spelunker.whosonfirst.org/id/1880762179) `macrocounty`.

This PR adds a 5th check: any record that has a _descendant_ with more than 2000 population is excluded from junk transliteration detection. For Greater London this obviously passes because the city of London is a descendant.

The process of calculating this value ended up being a bit more computationally intense than I would have liked, it takes about 6 minutes to build an in-memory tree of all records and their max descendant population. Maybe we can improve this in the future.

But it seems to work quite well, in our testing a bunch of British and French `macrocounty` records that are valid and have good translations are now properly handled.

About 8000 records are affected by this change.