### PR TITLE
Use plain Readable instead of combined-stream

### DIFF
--- a/cmd/wof_extract_sqlite.js
+++ b/cmd/wof_extract_sqlite.js
@@ -1,11 +1,11 @@
 const path = require('path');
 const fs = require('fs');
+const { Readable } = require('stream');
 const whosonfirst = require('pelias-whosonfirst');
 const config = require('pelias-config').generate().imports.whosonfirst;
 const SQLiteStream = whosonfirst.SQLiteStream;
 const through = require('through2');
 const Placeholder = require('../Placeholder');
-const combinedStream = require('combined-stream');
 const wof = require('../prototype/wof');
 const buildDescendantPopulationIndex = require('../lib/descendantPopulationIndex');
 
@@ -58,17 +58,18 @@ const output = () => {
   }
 };
 
-const sqliteStream = combinedStream.create();
-dbFiles.forEach(dbPath => {
-  sqliteStream.append(next => {
-    next(new SQLiteStream(
+async function* generateRecords() {
+  for (const dbPath of dbFiles) {
+    yield* new SQLiteStream(
       dbPath,
       config.importPlace ?
       SQLiteStream.findGeoJSONByPlacetypeAndWOFId(layers, config.importPlace) :
       SQLiteStream.findGeoJSONByPlacetype(layers)
-    ));
-  });
-});
+    );
+  }
+}
+
+const sqliteStream = Readable.from(generateRecords(), { objectMode: true });
 
 sqliteStream
   .pipe(whosonfirst.toJSONStream())


### PR DESCRIPTION
We already were not formally listing this dependency, and relying on the pelias-whosonfirst to depend on it transitively. Recently I noticed some tooling gets confused by that omission, so we should probably fix it.

`combined-stream` is easily replaceable with plain `Readable`, which seems like a nice option going forward.

For testing, I took two country WOF files and performed a build, all behaved normally.

Closes https://github.com/pelias/placeholder/issues/251